### PR TITLE
config: set site and base for deployment

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,6 @@
 import { defineConfig } from 'astro/config';
 // https://docs.astro.build/en/reference/configuration-reference/
-export default defineConfig({});
+export default defineConfig({
+  site: 'https://acwilan.github.io',
+  base: '/chords',
+});


### PR DESCRIPTION
## Summary
- configure Astro with site `https://acwilan.github.io`
- set base path `/chords`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be3f55b58c8330963eaf0d86fcacc3