### PR TITLE
Define songs content collection

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,9 +1,15 @@
 import { defineCollection, z } from 'astro:content';
 
-const examples = defineCollection({
+const songs = defineCollection({
   schema: z.object({
-    title: z.string()
-  })
+    title: z.string(),
+    key: z.string().optional(),
+    bpm: z.number().optional(),
+    capo: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    pdf: z.string().optional(),
+  }),
 });
 
-export const collections = { examples };
+export const collections = { songs };
+


### PR DESCRIPTION
## Summary
- add songs content collection with schema for title, key, bpm, capo, tags, and pdf

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68be40d2268c833092eef92d2783ae3d