### PR TITLE
Add songs index page

### DIFF
--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -1,0 +1,25 @@
+---
+import { getCollection } from 'astro:content';
+
+const songs = await getCollection('songs');
+songs.sort((a, b) => a.data.title.localeCompare(b.data.title));
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Songs</title>
+  </head>
+  <body>
+    <h1>Songs</h1>
+    <ul>
+      {songs.map((song) => (
+        <li>
+          <a href={`/songs/${song.slug}/`}>{song.data.title}</a>
+          {song.data.key && ` – ${song.data.key}`}
+        </li>
+      ))}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- list songs sorted by title and link to individual song pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be43fedc8c8330b34fc234b3f1f5ee