### PR TITLE
Display songs on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,10 @@
 ---
+import { getCollection } from 'astro:content';
+
+const songs = await getCollection('songs');
+songs.sort((a, b) => a.data.title.localeCompare(b.data.title));
 ---
+
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -8,6 +13,13 @@
   </head>
   <body>
     <h1>Chords</h1>
-    <p>Minimal Astro project.</p>
+    <ul>
+      {songs.map((song) => (
+        <li>
+          <a href={`/songs/${song.slug}/`}>{song.data.title}</a>
+          {song.data.key && ` – ${song.data.key}`}
+        </li>
+      ))}
+    </ul>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- list songs on the home page for easier discovery

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be4e3ec22c8330b182fbc62a56f5a3