### PR TITLE
Add shared layout with responsive header and footer

### DIFF
--- a/src/layouts/App.astro
+++ b/src/layouts/App.astro
@@ -1,0 +1,31 @@
+---
+import '../styles/global.css';
+
+const base = import.meta.env.BASE_URL.endsWith('/')
+  ? import.meta.env.BASE_URL
+  : `${import.meta.env.BASE_URL}/`;
+const year = new Date().getFullYear();
+---
+<html lang="en" class="h-full">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <slot name="head" />
+  </head>
+  <body class="flex min-h-screen flex-col">
+    <header class="bg-gray-100">
+      <div class="mx-auto max-w-3xl px-4 py-6 flex flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+        <a href={base} class="text-2xl font-bold">Chords</a>
+        <p class="text-sm text-gray-600">Chord charts for worship songs</p>
+      </div>
+    </header>
+    <main class="flex-1 mx-auto w-full max-w-3xl px-4 py-8">
+      <slot />
+    </main>
+    <footer class="bg-gray-100">
+      <div class="mx-auto max-w-3xl px-4 py-4 text-center text-sm text-gray-600">
+        &copy; {year} Chords
+      </div>
+    </footer>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import '../styles/global.css';
+import App from '../layouts/App.astro';
 import { getCollection } from 'astro:content';
 
 const songs = await getCollection('songs');
@@ -8,22 +8,17 @@ const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
 ---
-
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+<App>
+  <Fragment slot="head">
     <title>Chords</title>
-  </head>
-  <body>
-    <h1>Chords</h1>
-    <ul>
-      {songs.map((song) => (
-        <li>
-          <a href={`${base}songs/${song.slug}/`}>{song.data.title}</a>
-          {song.data.key && ` – ${song.data.key}`}
-        </li>
-      ))}
-    </ul>
-  </body>
-</html>
+  </Fragment>
+  <h1 class="mb-4 text-2xl font-bold">Songs</h1>
+  <ul class="space-y-1">
+    {songs.map((song) => (
+      <li>
+        <a href={`${base}songs/${song.slug}/`}>{song.data.title}</a>
+        {song.data.key && ` – ${song.data.key}`}
+      </li>
+    ))}
+  </ul>
+</App>


### PR DESCRIPTION
## Summary
- add `App.astro` layout with responsive header, tagline, and footer
- update index page to use the shared layout and center content

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be59ca837c8330a63278ad25bfec91