### PR TITLE
Add responsive sticky top navigation

### DIFF
--- a/src/layouts/App.astro
+++ b/src/layouts/App.astro
@@ -20,22 +20,42 @@ const year = new Date().getFullYear();
     </script>
     <slot name="head" />
   </head>
-  <body class="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-    <header class="bg-gray-100 dark:bg-gray-800">
-      <div class="mx-auto max-w-3xl px-4 py-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div class="flex flex-col">
-          <a href={base} class="text-2xl font-bold">Chords</a>
-          <p class="text-sm text-gray-600 dark:text-gray-300">Chord charts for worship songs</p>
+    <body class="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      <header class="sticky top-0 z-50 bg-gray-100 dark:bg-gray-800">
+        <div class="mx-auto max-w-3xl px-4 py-4">
+          <div class="flex items-center justify-between">
+            <a href={base} class="text-2xl font-bold">Chords</a>
+            <div class="flex items-center gap-2">
+              <button
+                id="menu-toggle"
+                class="sm:hidden rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700"
+                aria-controls="primary-navigation"
+                aria-expanded="false"
+              >
+                Menu
+              </button>
+              <nav
+                id="primary-navigation"
+                class="hidden flex-col gap-2 sm:flex sm:flex-row sm:items-center sm:gap-4"
+              >
+                <a href={base} class="hover:underline">Home</a>
+                <a href={`${base}songs/`} class="hover:underline">Songs</a>
+                <a href={`${base}changelog/`} class="hover:underline">Changelog</a>
+              </nav>
+              <button
+                id="theme-toggle"
+                class="rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700"
+                aria-label="Toggle dark mode"
+              >
+                Toggle theme
+              </button>
+            </div>
+          </div>
+          <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+            Chord charts for worship songs
+          </p>
         </div>
-        <button
-          id="theme-toggle"
-          class="self-end sm:self-auto rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700"
-          aria-label="Toggle dark mode"
-        >
-          Toggle theme
-        </button>
-      </div>
-    </header>
+      </header>
     <main class="flex-1 mx-auto w-full max-w-3xl px-4 py-8">
       <slot />
     </main>
@@ -44,11 +64,18 @@ const year = new Date().getFullYear();
         &copy; {year} @acwilan
       </div>
     </footer>
-    <script is:inline>
-      document.getElementById('theme-toggle')?.addEventListener('click', () => {
-        const isDark = document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-      });
-    </script>
+      <script is:inline>
+        document.getElementById('theme-toggle')?.addEventListener('click', () => {
+          const isDark = document.documentElement.classList.toggle('dark');
+          localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        });
+        const menuToggle = document.getElementById('menu-toggle');
+        const nav = document.getElementById('primary-navigation');
+        menuToggle?.addEventListener('click', () => {
+          const expanded = menuToggle.getAttribute('aria-expanded') === 'true';
+          menuToggle.setAttribute('aria-expanded', String(!expanded));
+          nav?.classList.toggle('hidden');
+        });
+      </script>
   </body>
 </html>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -1,0 +1,10 @@
+---
+import App from '../layouts/App.astro';
+---
+<App>
+  <Fragment slot="head">
+    <title>Changelog</title>
+  </Fragment>
+  <h1 class="mb-4 text-2xl font-bold">Changelog</h1>
+  <p>Coming soon.</p>
+</App>


### PR DESCRIPTION
## Summary
- add sticky top navigation bar with links to Home, Songs, and Changelog
- make navigation collapsible on mobile with accessible toggle
- add placeholder Changelog page

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68bf196c7bbc8330bb603ed00210f881