### PR TITLE
feat: apply site-wide typography

### DIFF
--- a/src/layouts/App.astro
+++ b/src/layouts/App.astro
@@ -56,7 +56,7 @@ const year = new Date().getFullYear();
           </p>
         </div>
       </header>
-    <main class="flex-1 mx-auto w-full max-w-3xl px-4 py-8">
+    <main class="prose dark:prose-invert flex-1 mx-auto w-full max-w-3xl px-4 py-8">
       <slot />
     </main>
     <footer class="bg-gray-100 dark:bg-gray-800">

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -5,6 +5,6 @@ import App from '../layouts/App.astro';
   <Fragment slot="head">
     <title>Changelog</title>
   </Fragment>
-  <h1 class="mb-4 text-2xl font-bold">Changelog</h1>
+  <h1>Changelog</h1>
   <p>Coming soon.</p>
 </App>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,8 +12,8 @@ const base = import.meta.env.BASE_URL.endsWith('/')
   <Fragment slot="head">
     <title>Chords</title>
   </Fragment>
-  <h1 class="mb-4 text-2xl font-bold">Songs</h1>
-  <ul class="space-y-1">
+  <h1>Songs</h1>
+  <ul>
     {songs.map((song) => (
       <li>
         <a href={`${base}songs/${song.slug}/`}>{song.data.title}</a>

--- a/src/pages/songs/[slug].astro
+++ b/src/pages/songs/[slug].astro
@@ -26,7 +26,7 @@ const pdf =
   <Fragment slot="head">
     <title>{song.data.title}</title>
   </Fragment>
-  <h1 class="mb-4 text-2xl font-bold">{song.data.title}</h1>
+  <h1>{song.data.title}</h1>
   {song.data.key && <p>Key: {song.data.key}</p>}
   {song.data.bpm && <p>BPM: {song.data.bpm}</p>}
   {song.data.capo && <p>Capo: {song.data.capo}</p>}

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -13,8 +13,8 @@ const base = import.meta.env.BASE_URL.endsWith('/')
   <Fragment slot="head">
     <title>Songs</title>
   </Fragment>
-  <h1 class="mb-4 text-2xl font-bold">Songs</h1>
-  <ul class="space-y-1">
+  <h1>Songs</h1>
+  <ul>
     {songs.map((song) => (
       <li>
         <a href={`${base}songs/${song.slug}/`}>{song.data.title}</a>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -9,6 +9,88 @@ export default {
         primary: '#1e3a8a',
         accent: '#f59e0b',
       },
+      typography: ({ theme }) => ({
+        DEFAULT: {
+          css: {
+            color: theme('colors.gray.800'),
+            a: {
+              color: theme('colors.primary'),
+              textDecoration: 'underline',
+              '&:hover': {
+                color: theme('colors.accent'),
+              },
+            },
+            h1: { color: theme('colors.gray.900'), fontWeight: '700' },
+            h2: { color: theme('colors.gray.900'), fontWeight: '700' },
+            h3: { color: theme('colors.gray.900'), fontWeight: '700' },
+            h4: { color: theme('colors.gray.900'), fontWeight: '700' },
+            code: {
+              color: theme('colors.gray.900'),
+              backgroundColor: theme('colors.gray.100'),
+              paddingLeft: '0.25rem',
+              paddingRight: '0.25rem',
+              paddingTop: '0.125rem',
+              paddingBottom: '0.125rem',
+              borderRadius: theme('borderRadius.sm'),
+            },
+            'pre code': {
+              backgroundColor: 'transparent',
+              padding: 0,
+            },
+            pre: {
+              color: theme('colors.gray.800'),
+              backgroundColor: theme('colors.gray.100'),
+              padding: theme('spacing.4'),
+              borderRadius: theme('borderRadius.md'),
+            },
+            ul: {
+              listStyleType: 'disc',
+              paddingLeft: '1.5em',
+            },
+            ol: {
+              listStyleType: 'decimal',
+              paddingLeft: '1.5em',
+            },
+            li: {
+              marginTop: theme('spacing.1'),
+              marginBottom: theme('spacing.1'),
+            },
+          },
+        },
+        invert: {
+          css: {
+            color: theme('colors.gray.100'),
+            a: {
+              color: theme('colors.accent'),
+              '&:hover': {
+                color: theme('colors.primary'),
+              },
+            },
+            h1: { color: theme('colors.gray.100') },
+            h2: { color: theme('colors.gray.100') },
+            h3: { color: theme('colors.gray.100') },
+            h4: { color: theme('colors.gray.100') },
+            code: {
+              color: theme('colors.gray.100'),
+              backgroundColor: theme('colors.gray.800'),
+            },
+            pre: {
+              color: theme('colors.gray.100'),
+              backgroundColor: theme('colors.gray.800'),
+            },
+            ul: {
+              listStyleType: 'disc',
+            },
+            ol: {
+              listStyleType: 'decimal',
+            },
+            li: {
+              marginTop: theme('spacing.1'),
+              marginBottom: theme('spacing.1'),
+            },
+          },
+        },
+      }),
     },
   },
   plugins: [typography()],


### PR DESCRIPTION
## Summary
- integrate Tailwind Typography plugin with custom colors, code and list spacing
- wrap main content in `prose` for consistent default styling
- simplify page headings and lists to rely on global typography

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bf1dbfe3cc8330bdf48c75b99a8bbb