### PR TITLE
feat: add hero section to home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,6 @@
 ---
 import App from '../layouts/App.astro';
-import { getCollection } from 'astro:content';
 
-const songs = await getCollection('songs');
-songs.sort((a, b) => a.data.title.localeCompare(b.data.title));
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
@@ -12,13 +9,15 @@ const base = import.meta.env.BASE_URL.endsWith('/')
   <Fragment slot="head">
     <title>Chords</title>
   </Fragment>
-  <h1>Songs</h1>
-  <ul>
-    {songs.map((song) => (
-      <li>
-        <a href={`${base}songs/${song.slug}/`}>{song.data.title}</a>
-        {song.data.key && ` – ${song.data.key}`}
-      </li>
-    ))}
-  </ul>
+  <section class="not-prose flex min-h-[60vh] flex-col items-center justify-center py-24 text-center">
+    <h1 class="text-5xl font-bold">Chords</h1>
+    <p class="mt-4 text-xl text-gray-600 dark:text-gray-300">Chord charts in PDF</p>
+    <a
+      href={`${base}songs/`}
+      class="mt-8 inline-block rounded bg-primary px-6 py-3 text-lg font-semibold text-white hover:bg-primary/90"
+    >
+      Browse songs
+    </a>
+  </section>
 </App>
+


### PR DESCRIPTION
## Summary
- add centered hero to landing page with site title, tagline, and link to songs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf20fddf408330898dfa898f836af3