### PR TITLE
feat: grid cards for songs

### DIFF
--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -16,7 +16,7 @@ const base = import.meta.env.BASE_URL.endsWith('/')
   <h1>Songs</h1>
   <ul class="grid list-none gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3">
     {songs.map((song) => (
-      <li>
+      <li class="list-none">
         <a
           href={`${base}songs/${song.slug}/`}
           class="block rounded border border-gray-200 bg-white p-4 transition hover:bg-gray-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700/50"
@@ -26,7 +26,7 @@ const base = import.meta.env.BASE_URL.endsWith('/')
             <p class="text-sm text-gray-600 dark:text-gray-400">Key: {song.data.key}</p>
           )}
           {song.data.tags && (
-            <ul class="mt-2 flex flex-wrap gap-1">
+            <ul class="mt-2 flex flex-wrap gap-1 list-none p-0">
               {song.data.tags.map((tag) => (
                 <li class="rounded bg-gray-200 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-200">
                   {tag}


### PR DESCRIPTION
## Summary
- display songs in responsive card grid
- include key, hover/focus states, and compact tag list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf232b7bbc8330bc023ab763c526bf