### PR TITLE
feat: add client-side song filtering

### DIFF
--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -4,6 +4,9 @@ import { getCollection } from 'astro:content';
 
 const songs = await getCollection('songs');
 songs.sort((a, b) => a.data.title.localeCompare(b.data.title));
+const tags = Array.from(
+  new Set(songs.flatMap((song) => song.data.tags ?? []))
+).sort();
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
@@ -14,9 +17,43 @@ const base = import.meta.env.BASE_URL.endsWith('/')
     <title>Songs</title>
   </Fragment>
   <h1>Songs</h1>
-  <ul class="grid list-none gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3">
+  <label for="song-search" class="sr-only">Search songs</label>
+  <input
+    id="song-search"
+    type="text"
+    placeholder="Search songs"
+    class="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+  />
+  {tags.length > 0 && (
+    <div
+      id="tag-filters"
+      class="mb-4 flex flex-wrap gap-2"
+      aria-label="Filter by tag"
+    >
+      {tags.map((tag) => (
+        <button
+          type="button"
+          data-tag={tag.toLowerCase()}
+          aria-pressed="false"
+          class="rounded-full bg-gray-200 px-3 py-1 text-sm text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:bg-gray-700 dark:text-gray-200"
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  )}
+  <ul
+    id="song-list"
+    class="grid list-none gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3"
+  >
     {songs.map((song) => (
-      <li class="list-none">
+      <li
+        class="list-none"
+        data-title={song.data.title.toLowerCase()}
+        data-tags={(song.data.tags ?? [])
+          .map((t) => t.toLowerCase())
+          .join(' ')}
+      >
         <a
           href={`${base}songs/${song.slug}/`}
           class="block rounded border border-gray-200 bg-white p-4 transition hover:bg-gray-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700/50"
@@ -39,4 +76,34 @@ const base = import.meta.env.BASE_URL.endsWith('/')
     ))}
   </ul>
   <p class="mt-8"><a href={base}>Go back</a></p>
+  <script is:inline>
+    const songItems = document.querySelectorAll('#song-list li');
+    const searchInput = document.getElementById('song-search');
+    const tagButtons = document.querySelectorAll('#tag-filters button');
+
+    function applyFilters() {
+      const query = searchInput.value.trim().toLowerCase();
+      const activeTags = Array.from(tagButtons)
+        .filter((btn) => btn.getAttribute('aria-pressed') === 'true')
+        .map((btn) => btn.dataset.tag);
+      songItems.forEach((item) => {
+        const title = item.dataset.title;
+        const tags = item.dataset.tags ? item.dataset.tags.split(' ') : [];
+        const matchesTitle = title.includes(query);
+        const matchesTags = activeTags.every((tag) => tags.includes(tag));
+        item.hidden = !(matchesTitle && matchesTags);
+      });
+    }
+
+    searchInput.addEventListener('input', applyFilters);
+    tagButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const pressed = btn.getAttribute('aria-pressed') === 'true';
+        btn.setAttribute('aria-pressed', String(!pressed));
+        btn.classList.toggle('bg-indigo-600', !pressed);
+        btn.classList.toggle('text-white', !pressed);
+        applyFilters();
+      });
+    });
+  </script>
 </App>


### PR DESCRIPTION
## Summary
- add search input and tag pills to /songs
- filter songs client-side by title and selected tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf8ddaa4ec8330811ab4ad6c824a74