### PR TITLE
Add custom 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,21 @@
+---
+import App from '../layouts/App.astro';
+const base = import.meta.env.BASE_URL.endsWith('/')
+  ? import.meta.env.BASE_URL
+  : `${import.meta.env.BASE_URL}/`;
+---
+<App>
+  <Fragment slot="head">
+    <title>Page Not Found</title>
+  </Fragment>
+  <section class="not-prose flex min-h-[60vh] flex-col items-center justify-center py-24 text-center">
+    <h1 class="text-5xl font-bold">404</h1>
+    <p class="mt-4 text-xl text-gray-600 dark:text-gray-300">Sorry, we couldn't find that page.</p>
+    <a
+      href={`${base}songs/`}
+      class="mt-8 inline-block rounded bg-primary px-6 py-3 text-lg font-semibold text-white hover:bg-primary/90"
+    >
+      Back to Songs
+    </a>
+  </section>
+</App>


### PR DESCRIPTION
## Summary
- add a friendly 404 page with link back to songs

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68bf911f5108833089db61813034356a