### PR TITLE
Run vitest without watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest --watch"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary
- Ensure `npm test` runs once and exits by default
- Add `test:watch` script for interactive development

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfadc6f71483309f697a6f3b34ad95