### PR TITLE
Add favicon, manifest, and basic SEO metadata

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Chords",
+  "short_name": "Chords",
+  "start_url": "/",
+  "display": "minimal-ui",
+  "background_color": "#ffffff",
+  "theme_color": "#111827",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/src/layouts/App.astro
+++ b/src/layouts/App.astro
@@ -18,6 +18,9 @@ const year = new Date().getFullYear();
         document.documentElement.classList.add('dark');
       }
     </script>
+    <link rel="icon" href={`${base}favicon.svg`} type="image/svg+xml" />
+    <link rel="manifest" href={`${base}manifest.webmanifest`} />
+    <meta property="og:site_name" content="Chords" />
     <slot name="head" />
   </head>
     <body class="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,10 +4,17 @@ import App from '../layouts/App.astro';
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const description = 'Chord charts in PDF for worship songs';
+const url = base;
 ---
 <App>
   <Fragment slot="head">
     <title>Chords</title>
+    <meta name="description" content={description} />
+    <meta property="og:title" content="Chords" />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={url} />
   </Fragment>
   <section class="not-prose flex min-h-[60vh] flex-col items-center justify-center py-24 text-center">
     <h1 class="text-5xl font-bold">Chords</h1>

--- a/src/pages/songs/[slug].astro
+++ b/src/pages/songs/[slug].astro
@@ -21,10 +21,17 @@ const pdf =
   (song.data.pdf.startsWith('http')
     ? song.data.pdf
     : `${base}${song.data.pdf.replace(/^\//, '')}`);
+const url = `${base}songs/${slug}/`;
+const description = `Chord chart for ${song.data.title}`;
 ---
 <App>
   <Fragment slot="head">
     <title>{song.data.title}</title>
+    <meta name="description" content={description} />
+    <meta property="og:title" content={song.data.title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content={url} />
   </Fragment>
   <header class="mb-8 border-b pb-4">
     <h1 class="mb-2 text-3xl font-bold">{song.data.title}</h1>

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -10,11 +10,18 @@ const tags = Array.from(
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const description = 'Browse and search chord charts for worship songs';
+const url = `${base}songs/`;
 ---
 
 <App>
   <Fragment slot="head">
     <title>Songs</title>
+    <meta name="description" content={description} />
+    <meta property="og:title" content="Songs" />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={url} />
   </Fragment>
   <h1>Songs</h1>
   <label for="song-search" class="sr-only">Search songs</label>


### PR DESCRIPTION
## Summary
- add favicon link, site manifest, and default Open Graph site name
- include titles, descriptions, and Open Graph tags for home, songs list, and song detail pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfae405ef0833099c636577c15574c