### PR TITLE
feat: add reusable tailwind components

### DIFF
--- a/src/layouts/App.astro
+++ b/src/layouts/App.astro
@@ -31,7 +31,7 @@ const year = new Date().getFullYear();
             <div class="flex items-center gap-2">
               <button
                 id="menu-toggle"
-                class="sm:hidden rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700"
+                class="btn-secondary sm:hidden px-2 py-1 text-sm"
                 aria-controls="primary-navigation"
                 aria-expanded="false"
               >
@@ -47,7 +47,7 @@ const year = new Date().getFullYear();
               </nav>
               <button
                 id="theme-toggle"
-                class="rounded border border-gray-300 bg-white p-2 dark:border-gray-600 dark:bg-gray-700"
+                class="btn-secondary p-2"
                 aria-label="Toggle dark mode"
               >
                 <svg

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -13,7 +13,7 @@ const base = import.meta.env.BASE_URL.endsWith('/')
     <p class="mt-4 text-xl text-gray-600 dark:text-gray-300">Sorry, we couldn't find that page.</p>
     <a
       href={`${base}songs/`}
-      class="mt-8 inline-block rounded bg-primary px-6 py-3 text-lg font-semibold text-white hover:bg-primary/90"
+      class="btn-primary mt-8 px-6 py-3 text-lg"
     >
       Back to Songs
     </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,7 @@ const url = base;
     <p class="mt-4 text-xl text-gray-600 dark:text-gray-300">Chord charts in PDF</p>
     <a
       href={`${base}songs/`}
-      class="mt-8 inline-block rounded bg-primary px-6 py-3 text-lg font-semibold text-white hover:bg-primary/90 dark:hover:bg-primary/80"
+      class="btn-primary mt-8 px-6 py-3 text-lg"
     >
       Browse songs
     </a>

--- a/src/pages/songs/[slug].astro
+++ b/src/pages/songs/[slug].astro
@@ -49,7 +49,7 @@ const description = `Chord chart for ${song.data.title}`;
     {song.data.tags && (
       <div class="mt-2 flex flex-wrap gap-2">
         {song.data.tags.map((tag) => (
-          <span class="rounded bg-gray-200 px-2 py-1 text-xs dark:bg-gray-700">{tag}</span>
+          <span class="tag-pill">{tag}</span>
         ))}
       </div>
     )}
@@ -61,19 +61,19 @@ const description = `Chord chart for ${song.data.title}`;
         <a
           href={pdf}
           download
-          class="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+          class="btn-primary"
         >
           Download PDF
         </a>
         <a
           href={pdf}
           target="_blank"
-          class="rounded bg-gray-600 px-4 py-2 text-white hover:bg-gray-700 dark:bg-gray-500 dark:hover:bg-gray-600"
+          class="btn-secondary"
         >
           Open PDF
         </a>
       </div>
-      <div class="mt-4 overflow-hidden rounded border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <div class="card mt-4 overflow-hidden p-0">
         <object data={pdf} type="application/pdf" class="h-[80vh] w-full bg-white dark:bg-gray-900">
           <p>
             <a href={pdf}>Download PDF</a>

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -29,7 +29,7 @@ const url = `${base}songs/`;
     id="song-search"
     type="text"
     placeholder="Search songs"
-    class="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+    class="input mb-4 w-full"
   />
   {tags.length > 0 && (
     <div
@@ -42,7 +42,7 @@ const url = `${base}songs/`;
           type="button"
           data-tag={tag.toLowerCase()}
           aria-pressed="false"
-          class="rounded-full bg-gray-200 px-3 py-1 text-sm text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:bg-gray-700 dark:text-gray-200"
+          class="tag-pill px-3 py-1 text-sm"
         >
           {tag}
         </button>
@@ -63,7 +63,7 @@ const url = `${base}songs/`;
       >
         <a
           href={`${base}songs/${song.slug}/`}
-          class="block rounded border border-gray-200 bg-white p-4 transition hover:bg-gray-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700/50"
+          class="card block"
         >
           <h2 class="text-lg font-semibold">{song.data.title}</h2>
           {song.data.key && (
@@ -72,9 +72,7 @@ const url = `${base}songs/`;
           {song.data.tags && (
             <ul class="mt-2 flex flex-wrap gap-1 list-none p-0">
               {song.data.tags.map((tag) => (
-                <li class="rounded bg-gray-200 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-200">
-                  {tag}
-                </li>
+                <li class="tag-pill">{tag}</li>
               ))}
             </ul>
           )}
@@ -107,7 +105,7 @@ const url = `${base}songs/`;
       btn.addEventListener('click', () => {
         const pressed = btn.getAttribute('aria-pressed') === 'true';
         btn.setAttribute('aria-pressed', String(!pressed));
-        btn.classList.toggle('bg-indigo-600', !pressed);
+        btn.classList.toggle('bg-primary', !pressed);
         btn.classList.toggle('text-white', !pressed);
         applyFilters();
       });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,21 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .btn-primary {
+    @apply inline-block rounded bg-primary px-4 py-2 font-semibold text-white hover:bg-primary/90 dark:hover:bg-primary/80;
+  }
+  .btn-secondary {
+    @apply inline-block rounded border border-gray-300 bg-white px-4 py-2 text-gray-900 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100;
+  }
+  .tag-pill {
+    @apply inline-block rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:bg-gray-700 dark:text-gray-200;
+  }
+  .card {
+    @apply rounded border border-gray-200 bg-white p-4 transition hover:bg-gray-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700/50;
+  }
+  .input {
+    @apply rounded border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100;
+  }
+}


### PR DESCRIPTION
## Summary
- add Tailwind component classes for buttons, pills, cards, and inputs
- refactor pages to use reusable component classes

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bfaf53d31c833087d516154f621602