### PR TITLE
feat: add artist filter sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository hosts the source code for the chords site.
 
 1. Add an `.md` file in `src/content/songs/` with the song's frontmatter.
 2. Provide `slug`, `lang` (`es` or `en`), `title` and optional fields like `key`, `bpm`, `artist`, `author`, `tags` and `pdf`.
+   The `artist` field is used to build the artist filter on the songs page.
 3. Place the PDF chart in `public/charts/` with the same name referenced in the frontmatter.
 
 ## Localization
@@ -23,6 +24,13 @@ This repository hosts the source code for the chords site.
 
 - `artist` and `author` are optional metadata fields.
 - `capo` is no longer supported.
+
+## Artist filter
+
+The songs index includes a collapsible sidebar listing all artists. Selecting an artist filters
+the visible songs without reloading the page. The choice is saved in `localStorage` under
+`artistFilter` and reflected in the URL as `?artist=Name` for easy sharing. Use the **All** option to
+clear the filter, which removes the query parameter and stored value.
 
 ## Running locally
 

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -167,7 +167,6 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
     const songItems = document.querySelectorAll('#song-list li');
     const searchInput = document.getElementById('song-search');
     const tagButtons = document.querySelectorAll('#tag-filters button');
-    window.activeArtist = {JSON.stringify(initialArtist ?? '')};
     function applyFilters() {
       const query = searchInput.value.trim().toLowerCase();
       const activeTags = Array.from(tagButtons)

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -164,7 +164,7 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
     {JSON.stringify(artists)}
   </script>
   <script is:inline>
-    const songItems = document.querySelectorAll('#song-list li');
+    const songItems = document.querySelectorAll('#song-list > li');
     const searchInput = document.getElementById('song-search');
     const tagButtons = document.querySelectorAll('#tag-filters button');
     function applyFilters() {
@@ -173,7 +173,7 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
         .filter((btn) => btn.getAttribute('aria-pressed') === 'true')
         .map((btn) => btn.dataset.tag);
       songItems.forEach((item) => {
-        const title = item.dataset.title;
+        const title = item.dataset.title || '';
         const tags = item.dataset.tags ? item.dataset.tags.split(' ') : [];
         const itemArtist = item.dataset.artist || 'Unknown';
         const matchesTitle = title.includes(query);

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -2,7 +2,6 @@
 import App from '../../layouts/App.astro';
 import { getCollection } from 'astro:content';
 import { getLocaleFromUrl, createT } from '../../utils/i18n';
-import artistFilter from '../../scripts/artistFilter';
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
@@ -195,7 +194,9 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
       });
     });
   </script>
-  <script is:inline client:load>
-    artistFilter();
-  </script>
+  <script
+    type="module"
+    src={Astro.resolve('../../scripts/artistFilter.ts')}
+    client:load
+  ></script>
 </App>

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -2,6 +2,7 @@
 import App from '../../layouts/App.astro';
 import { getCollection } from 'astro:content';
 import { getLocaleFromUrl, createT } from '../../utils/i18n';
+import artistFilter from '../../scripts/artistFilter';
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
@@ -24,6 +25,15 @@ const songs = Array.from(map.entries()).map(([slug, langs]) => {
 });
 songs.sort((a, b) => a.entry.data.title.localeCompare(b.entry.data.title));
 const tags = Array.from(new Set(songs.flatMap((s) => s.entry.data.tags ?? []))).sort();
+const artistCounts = new Map();
+for (const song of songs) {
+  const artist = song.entry.data.artist || 'Unknown';
+  artistCounts.set(artist, (artistCounts.get(artist) || 0) + 1);
+}
+const artists = Array.from(artistCounts.entries()).sort((a, b) =>
+  a[0].localeCompare(b[0])
+);
+const initialArtist = Astro.url.searchParams.get('artist');
 const description = t('songs.description');
 const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
 ---
@@ -37,71 +47,127 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
     <meta property="og:url" content={url} />
   </Fragment>
   <h1>{t('songs.title')}</h1>
-  <label for="song-search" class="sr-only">{t('songs.searchPlaceholder')}</label>
-  <input
-    id="song-search"
-    type="text"
-    placeholder={t('songs.searchPlaceholder')}
-    class="input mb-4 w-full"
-  />
-  {tags.length > 0 && (
-    <div
-      id="tag-filters"
-      class="mb-4 flex flex-wrap gap-2"
-      aria-label={t('songs.tagFilterLabel')}
-    >
-      {tags.map((tag) => (
-        <button
-          type="button"
-          data-tag={tag.toLowerCase()}
-          aria-pressed="false"
-          class="tag-pill px-3 py-1 text-sm"
-        >
-          {tag}
-        </button>
-      ))}
-    </div>
-  )}
-  <ul
-    id="song-list"
-    class="grid list-none gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3"
+  <button
+    id="artist-sidebar-toggle"
+    class="mb-4 md:hidden"
+    aria-controls="artist-sidebar"
+    aria-expanded="false"
+    type="button"
   >
-    {songs.map((song) => (
-      <li
-        class="list-none"
-        data-title={song.entry.data.title.toLowerCase()}
-        data-tags={(song.entry.data.tags ?? [])
-          .map((t) => t.toLowerCase())
-          .join(' ')}
-      >
-        <a
-          href={`${base}${song.linkLocale === 'en' ? 'en/' : ''}songs/${song.slug}/`}
-          class="card block"
+    {t('songs.artist')}
+  </button>
+  <div class="md:flex md:gap-4">
+    <aside
+      id="artist-sidebar"
+      class="mb-4 hidden w-48 shrink-0 md:block"
+    >
+      <nav aria-label="Artist filters">
+        <ul id="artist-filters" class="space-y-2">
+          <li>
+            <button
+              type="button"
+              data-artist=""
+              aria-pressed={initialArtist ? 'false' : 'true'}
+              class="block w-full text-left"
+            >
+              All ({songs.length})
+            </button>
+          </li>
+          {artists.map(([name, count]) => (
+            <li>
+              <button
+                type="button"
+                data-artist={name}
+                aria-pressed={initialArtist === name ? 'true' : 'false'}
+                class="block w-full text-left"
+              >
+                {name} ({count})
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+    <div class="flex-1">
+      <label for="song-search" class="sr-only">{t('songs.searchPlaceholder')}</label>
+      <input
+        id="song-search"
+        type="text"
+        placeholder={t('songs.searchPlaceholder')}
+        class="input mb-4 w-full"
+      />
+      {tags.length > 0 && (
+        <div
+          id="tag-filters"
+          class="mb-4 flex flex-wrap gap-2"
+          aria-label={t('songs.tagFilterLabel')}
         >
-          <h2 class="text-lg font-semibold">{song.entry.data.title}</h2>
-          {song.entry.data.artist && (
-            <p class="text-sm text-gray-600 dark:text-gray-400">{song.entry.data.artist}</p>
-          )}
-          {song.entry.data.key && (
-            <p class="text-sm text-gray-600 dark:text-gray-400">{t('songs.key')}: {song.entry.data.key}</p>
-          )}
-          {song.entry.data.tags && (
-            <ul class="mt-2 flex flex-wrap gap-1 list-none p-0">
-              {song.entry.data.tags.map((tag) => (
-                <li class="tag-pill">{tag}</li>
-              ))}
-            </ul>
-          )}
-        </a>
-      </li>
-    ))}
-  </ul>
-  <p class="mt-8"><a href={base}>{t('songs.goBack')}</a></p>
+          {tags.map((tag) => (
+            <button
+              type="button"
+              data-tag={tag.toLowerCase()}
+              aria-pressed="false"
+              class="tag-pill px-3 py-1 text-sm"
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      )}
+      <ul
+        id="song-list"
+        class="grid list-none gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3"
+      >
+        {songs.map((song) => {
+          const artist = song.entry.data.artist || 'Unknown';
+          const hidden =
+            initialArtist && artist !== initialArtist ? true : false;
+          return (
+            <li
+              class="list-none"
+              data-title={song.entry.data.title.toLowerCase()}
+              data-tags={(song.entry.data.tags ?? [])
+                .map((t) => t.toLowerCase())
+                .join(' ')}
+              data-artist={artist}
+              hidden={hidden}
+            >
+              <a
+                href={`${base}${song.linkLocale === 'en' ? 'en/' : ''}songs/${song.slug}/`}
+                class="card block"
+              >
+                <h2 class="text-lg font-semibold">{song.entry.data.title}</h2>
+                {song.entry.data.artist && (
+                  <p class="text-sm text-gray-600 dark:text-gray-400">{song.entry.data.artist}</p>
+                )}
+                {song.entry.data.key && (
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    {t('songs.key')}: {song.entry.data.key}
+                  </p>
+                )}
+                {song.entry.data.tags && (
+                  <ul class="mt-2 flex flex-wrap gap-1 list-none p-0">
+                    {song.entry.data.tags.map((tag) => (
+                      <li class="tag-pill">{tag}</li>
+                    ))}
+                  </ul>
+                )}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+      <p class="mt-8"><a href={base}>{t('songs.goBack')}</a></p>
+    </div>
+  </div>
+  <script id="artist-data" type="application/json">
+    {JSON.stringify(artists)}
+  </script>
   <script is:inline>
     const songItems = document.querySelectorAll('#song-list li');
     const searchInput = document.getElementById('song-search');
     const tagButtons = document.querySelectorAll('#tag-filters button');
-
+    window.activeArtist = {JSON.stringify(initialArtist ?? '')};
     function applyFilters() {
       const query = searchInput.value.trim().toLowerCase();
       const activeTags = Array.from(tagButtons)
@@ -110,12 +176,14 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
       songItems.forEach((item) => {
         const title = item.dataset.title;
         const tags = item.dataset.tags ? item.dataset.tags.split(' ') : [];
+        const itemArtist = item.dataset.artist || 'Unknown';
         const matchesTitle = title.includes(query);
         const matchesTags = activeTags.every((tag) => tags.includes(tag));
-        item.hidden = !(matchesTitle && matchesTags);
+        const matchesArtist = !window.activeArtist || itemArtist === window.activeArtist;
+        item.hidden = !(matchesTitle && matchesTags && matchesArtist);
       });
     }
-
+    window.applySongFilters = applyFilters;
     searchInput.addEventListener('input', applyFilters);
     tagButtons.forEach((btn) => {
       btn.addEventListener('click', () => {
@@ -126,5 +194,8 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
         applyFilters();
       });
     });
+  </script>
+  <script is:inline client:load>
+    artistFilter();
   </script>
 </App>

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -2,6 +2,7 @@
 import App from '../../layouts/App.astro';
 import { getCollection } from 'astro:content';
 import { getLocaleFromUrl, createT } from '../../utils/i18n';
+import artistFilter from '../../scripts/artistFilter.ts?url';
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
@@ -194,9 +195,5 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
       });
     });
   </script>
-  <script
-    type="module"
-    src={Astro.resolve('../../scripts/artistFilter.ts')}
-    client:load
-  ></script>
+  <script type="module" src={artistFilter} client:load></script>
 </App>

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -2,7 +2,7 @@
 import App from '../../layouts/App.astro';
 import { getCollection } from 'astro:content';
 import { getLocaleFromUrl, createT } from '../../utils/i18n';
-import artistFilter from '../../scripts/artistFilter.ts?url';
+import artistFilterScript from '../../scripts/artistFilter.js?url';
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
@@ -195,5 +195,5 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
       });
     });
   </script>
-  <script type="module" src={artistFilter} client:load></script>
+  <script type="module" src={artistFilterScript}></script>
 </App>

--- a/src/scripts/artistFilter.js
+++ b/src/scripts/artistFilter.js
@@ -1,29 +1,12 @@
 const STORAGE_KEY = 'artistFilter';
 
-declare global {
-  interface Window {
-    activeArtist: string;
-    applySongFilters?: () => void;
-  }
-}
-
 export default function artistFilter() {
   const sidebar = document.getElementById('artist-sidebar');
   const toggle = document.getElementById('artist-sidebar-toggle');
-  const buttons = sidebar?.querySelectorAll<HTMLButtonElement>('[data-artist]');
+  const buttons = sidebar?.querySelectorAll('[data-artist]');
   if (!sidebar || !toggle || !buttons) return;
 
-  const artistData = document.getElementById('artist-data');
-  let _artists: any = [];
-  if (artistData) {
-    try {
-      _artists = JSON.parse(artistData.textContent || '[]');
-    } catch {
-      _artists = [];
-    }
-  }
-
-  function updateURL(artist: string) {
+  function updateURL(artist) {
     const url = new URL(window.location.href);
     if (artist) {
       url.searchParams.set('artist', artist);
@@ -33,10 +16,10 @@ export default function artistFilter() {
     history.replaceState({}, '', url.toString());
   }
 
-  function activate(artist: string) {
+  function activate(artist) {
     window.activeArtist = artist;
     buttons.forEach((btn) => {
-      const isActive = (btn as HTMLButtonElement).dataset.artist === artist;
+      const isActive = btn.dataset.artist === artist;
       btn.setAttribute('aria-pressed', String(isActive));
       btn.classList.toggle('font-bold', isActive);
     });
@@ -46,12 +29,14 @@ export default function artistFilter() {
       localStorage.removeItem(STORAGE_KEY);
     }
     updateURL(artist);
-    window.applySongFilters?.();
+    if (window.applySongFilters) {
+      window.applySongFilters();
+    }
   }
 
   buttons.forEach((btn) => {
     btn.addEventListener('click', () => {
-      const artist = (btn as HTMLButtonElement).dataset.artist || '';
+      const artist = btn.dataset.artist || '';
       activate(artist);
     });
   });

--- a/src/scripts/artistFilter.ts
+++ b/src/scripts/artistFilter.ts
@@ -73,3 +73,5 @@ export default function artistFilter() {
   }
   activate(selected || '');
 }
+
+artistFilter();

--- a/src/scripts/artistFilter.ts
+++ b/src/scripts/artistFilter.ts
@@ -1,0 +1,75 @@
+const STORAGE_KEY = 'artistFilter';
+
+declare global {
+  interface Window {
+    activeArtist: string;
+    applySongFilters?: () => void;
+  }
+}
+
+export default function artistFilter() {
+  const sidebar = document.getElementById('artist-sidebar');
+  const toggle = document.getElementById('artist-sidebar-toggle');
+  const buttons = sidebar?.querySelectorAll<HTMLButtonElement>('[data-artist]');
+  if (!sidebar || !toggle || !buttons) return;
+
+  const artistData = document.getElementById('artist-data');
+  let _artists: any = [];
+  if (artistData) {
+    try {
+      _artists = JSON.parse(artistData.textContent || '[]');
+    } catch {
+      _artists = [];
+    }
+  }
+
+  function updateURL(artist: string) {
+    const url = new URL(window.location.href);
+    if (artist) {
+      url.searchParams.set('artist', artist);
+    } else {
+      url.searchParams.delete('artist');
+    }
+    history.replaceState({}, '', url.toString());
+  }
+
+  function activate(artist: string) {
+    window.activeArtist = artist;
+    buttons.forEach((btn) => {
+      const isActive = (btn as HTMLButtonElement).dataset.artist === artist;
+      btn.setAttribute('aria-pressed', String(isActive));
+      btn.classList.toggle('font-bold', isActive);
+    });
+    if (artist) {
+      localStorage.setItem(STORAGE_KEY, artist);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+    updateURL(artist);
+    window.applySongFilters?.();
+  }
+
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const artist = (btn as HTMLButtonElement).dataset.artist || '';
+      activate(artist);
+    });
+  });
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    sidebar.classList.toggle('hidden', expanded);
+  });
+
+  let selected = new URLSearchParams(window.location.search).get('artist');
+  if (selected) {
+    localStorage.setItem(STORAGE_KEY, selected);
+  } else {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      selected = stored;
+    }
+  }
+  activate(selected || '');
+}


### PR DESCRIPTION
## Summary
- add collapsible artist sidebar with counts on songs page
- persist artist selection in URL and localStorage for filtering
- document artist field and filter behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e6a0d4888330ab6af85b6f8c33a6