### PR TITLE
feat: improve songs sidebar UX

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -20,6 +20,8 @@
     "key": "Key",
     "bpm": "BPM",
     "artist": "Artist",
+    "artists": "Artists",
+    "clear": "Clear",
     "author": "Author",
     "downloadPdf": "Download PDF",
     "openPdf": "Open PDF",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -20,6 +20,8 @@
     "key": "Tonalidad",
     "bpm": "BPM",
     "artist": "Artista",
+    "artists": "Artistas",
+    "clear": "Limpiar",
     "author": "Autor",
     "downloadPdf": "Descargar PDF",
     "openPdf": "Abrir PDF",

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -49,18 +49,38 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
   <h1>{t('songs.title')}</h1>
   <button
     id="artist-sidebar-toggle"
-    class="mb-4 md:hidden"
+    class="mb-4 flex items-center md:hidden"
     aria-controls="artist-sidebar"
     aria-expanded="false"
     type="button"
   >
-    {t('songs.artist')}
+    {t('songs.artists')}
+    <svg
+      class="ml-2 h-4 w-4 transition-transform"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+    </svg>
   </button>
   <div class="md:flex md:gap-4">
     <aside
       id="artist-sidebar"
       class="mb-4 hidden w-48 shrink-0 md:block"
     >
+      <div class="mb-2 flex items-center justify-between">
+        <h2 class="text-sm font-semibold">{t('songs.artists')}</h2>
+        <button
+          id="artist-clear"
+          type="button"
+          class="text-xs text-gray-600 hover:underline dark:text-gray-400"
+        >
+          {t('songs.clear')}
+        </button>
+      </div>
       <nav aria-label="Artist filters">
         <ul id="artist-filters" class="space-y-2">
           <li>
@@ -68,9 +88,10 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
               type="button"
               data-artist=""
               aria-pressed={initialArtist ? 'false' : 'true'}
-              class="block w-full text-left"
+              class="flex w-full items-center justify-between rounded-full px-3 py-1 text-sm"
             >
-              All ({songs.length})
+              <span>All</span>
+              <span class="text-xs text-gray-600 dark:text-gray-400">{songs.length}</span>
             </button>
           </li>
           {artists.map(([name, count]) => (
@@ -79,9 +100,10 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
                 type="button"
                 data-artist={name}
                 aria-pressed={initialArtist === name ? 'true' : 'false'}
-                class="block w-full text-left"
+                class="flex w-full items-center justify-between rounded-full px-3 py-1 text-sm"
               >
-                {name} ({count})
+                <span>{name}</span>
+                <span class="text-xs text-gray-600 dark:text-gray-400">{count}</span>
               </button>
             </li>
           ))}

--- a/src/scripts/artistFilter.js
+++ b/src/scripts/artistFilter.js
@@ -3,6 +3,7 @@ const STORAGE_KEY = 'artistFilter';
 export default function artistFilter() {
   const sidebar = document.getElementById('artist-sidebar');
   const toggle = document.getElementById('artist-sidebar-toggle');
+  const clear = document.getElementById('artist-clear');
   const buttons = sidebar?.querySelectorAll('[data-artist]');
   if (!sidebar || !toggle || !buttons) return;
 
@@ -21,7 +22,8 @@ export default function artistFilter() {
     buttons.forEach((btn) => {
       const isActive = btn.dataset.artist === artist;
       btn.setAttribute('aria-pressed', String(isActive));
-      btn.classList.toggle('font-bold', isActive);
+      btn.classList.toggle('bg-gray-200', isActive);
+      btn.classList.toggle('dark:bg-gray-700', isActive);
     });
     if (artist) {
       localStorage.setItem(STORAGE_KEY, artist);
@@ -41,10 +43,15 @@ export default function artistFilter() {
     });
   });
 
+  clear?.addEventListener('click', () => {
+    activate('');
+  });
+
   toggle.addEventListener('click', () => {
     const expanded = toggle.getAttribute('aria-expanded') === 'true';
     toggle.setAttribute('aria-expanded', String(!expanded));
     sidebar.classList.toggle('hidden', expanded);
+    toggle.querySelector('svg')?.classList.toggle('rotate-180', !expanded);
   });
 
   let selected = new URLSearchParams(window.location.search).get('artist');


### PR DESCRIPTION
## Summary
- add collapsible artists sidebar with header and clear button
- style active artist filter as pill and keep counts aligned
- rotate chevron on mobile toggle and reset artist filter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1bca83c908330ae24c41b7c6156de