### PR TITLE
feat: add fuzzy search to songs page

### DIFF
--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -185,27 +185,52 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
   <script id="artist-data" type="application/json">
     {JSON.stringify(artists)}
   </script>
-  <script is:inline>
+  <script is:inline type="module">
+    import Fuse from 'https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.esm.js';
+
     const songItems = document.querySelectorAll('#song-list > li');
     const searchInput = document.getElementById('song-search');
     const tagButtons = document.querySelectorAll('#tag-filters button');
+
+    const songs = Array.from(songItems).map((element) => ({
+      element,
+      title: element.dataset.title || '',
+      artist: element.dataset.artist || 'Unknown',
+      tags: element.dataset.tags ? element.dataset.tags.split(' ') : [],
+    }));
+
+    const fuse = new Fuse(songs, {
+      keys: ['title', 'artist', 'tags'],
+      threshold: 0.3,
+      ignoreLocation: true,
+    });
+
     function applyFilters() {
-      const query = searchInput.value.trim().toLowerCase();
+      const query = searchInput.value.trim();
       const activeTags = Array.from(tagButtons)
         .filter((btn) => btn.getAttribute('aria-pressed') === 'true')
         .map((btn) => btn.dataset.tag);
-      songItems.forEach((item) => {
-        const title = item.dataset.title || '';
-        const tags = item.dataset.tags ? item.dataset.tags.split(' ') : [];
-        const itemArtist = item.dataset.artist || 'Unknown';
-        const matchesTitle = title.includes(query);
-        const matchesTags = activeTags.every((tag) => tags.includes(tag));
-        const matchesArtist = !window.activeArtist || itemArtist === window.activeArtist;
-        item.hidden = !(matchesTitle && matchesTags && matchesArtist);
+
+      const results = query ? fuse.search(query).map((r) => r.item) : songs;
+      const resultSet = new Set(results);
+      const activeArtist = window.activeArtist;
+
+      songs.forEach((song) => {
+        const matchesSearch = resultSet.has(song);
+        const matchesTags = activeTags.every((tag) => song.tags.includes(tag));
+        const matchesArtist = !activeArtist || song.artist === activeArtist;
+        song.element.hidden = !(matchesSearch && matchesTags && matchesArtist);
       });
     }
+
     window.applySongFilters = applyFilters;
-    searchInput.addEventListener('input', applyFilters);
+
+    let debounce;
+    searchInput.addEventListener('input', () => {
+      clearTimeout(debounce);
+      debounce = setTimeout(applyFilters, 200);
+    });
+
     tagButtons.forEach((btn) => {
       btn.addEventListener('click', () => {
         const pressed = btn.getAttribute('aria-pressed') === 'true';


### PR DESCRIPTION
## Summary
- integrate Fuse.js for fuzzy title/artist/tag search on the songs page
- debounce search input by 200ms and respect artist selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e5dbab4c8330946de313e315123d