### PR TITLE
feat: add keyboard shortcuts for song search

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -16,6 +16,7 @@
     "title": "Songs",
     "description": "Browse and search chord charts for worship songs",
     "searchPlaceholder": "Search songs",
+    "searchTip": "Press '/' to focus search. Press 'Esc' to clear search or artist filter.",
     "count": "{count} songs",
     "tagFilterLabel": "Filter by tag",
     "key": "Key",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -16,6 +16,7 @@
     "title": "Canciones",
     "description": "Buscar y explorar cifras de canciones de adoración",
     "searchPlaceholder": "Buscar canciones",
+    "searchTip": "Presiona '/' para enfocar la búsqueda. Presiona 'Esc' para limpiar la búsqueda o el filtro de artista.",
     "count": "{count} canciones",
     "tagFilterLabel": "Filtrar por etiqueta",
     "key": "Tonalidad",

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -271,7 +271,6 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
           e.target instanceof HTMLTextAreaElement ||
           e.target instanceof HTMLSelectElement
         ) {
-          e.preventDefault();
           return;
         }
         e.preventDefault();

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -272,7 +272,9 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
           e.target instanceof HTMLSelectElement
         ) {
           e.preventDefault();
+          return;
         }
+        e.preventDefault();
         searchInput.focus();
       } else if (e.key === 'Escape') {
         e.preventDefault();

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -120,8 +120,11 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
         id="song-search"
         type="text"
         placeholder={t('songs.searchPlaceholder')}
-        class="input mb-4 w-full"
+        class="input mb-2 w-full"
       />
+      <p class="mb-4 text-xs text-gray-600 dark:text-gray-400">
+        {t('songs.searchTip')}
+      </p>
       {tags.length > 0 && (
         <div
           id="tag-filters"
@@ -259,6 +262,27 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
         btn.classList.toggle('text-white', !pressed);
         applyFilters();
       });
+    });
+
+    window.addEventListener('keydown', (e) => {
+      if (e.key === '/' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (
+          e.target instanceof HTMLInputElement ||
+          e.target instanceof HTMLTextAreaElement ||
+          e.target instanceof HTMLSelectElement
+        ) {
+          e.preventDefault();
+        }
+        searchInput.focus();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        if (searchInput.value) {
+          searchInput.value = '';
+          applyFilters();
+        } else {
+          document.getElementById('artist-clear')?.click();
+        }
+      }
     });
   </script>
   <script type="module" src={artistFilterScript}></script>


### PR DESCRIPTION
## Summary
- add `/` and `Esc` shortcuts for quick song search and filter clearing
- show tooltip under the search box describing the shortcuts
- localize tooltip text in English and Spanish

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ea327ba083308c3ef5cc3de5449f