### PR TITLE
feat: refine artist filter persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ This repository hosts the source code for the chords site.
 
 The songs index includes a collapsible sidebar listing all artists. Selecting an artist filters
 the visible songs without reloading the page. The choice is saved in `localStorage` under
-`artistFilter` and reflected in the URL as `?artist=Name` for easy sharing. Use the **All** option to
-clear the filter, which removes the query parameter and stored value.
+`artistFilter` and reflected in the URL as `?artist=Name` for easy sharing. An active selection is
+highlighted in the sidebar and shown above the results as a removable chip. Use the **All** option or
+click the chip to clear the filter, which removes the query parameter and stored value.
 
 ## Running locally
 

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -143,6 +143,7 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
           ))}
         </div>
       )}
+      <div id="active-artist" class="mb-4" data-label={t('songs.artist')}></div>
       <p
         id="song-count"
         class="mb-4"

--- a/src/scripts/artistFilter.js
+++ b/src/scripts/artistFilter.js
@@ -4,6 +4,8 @@ export default function artistFilter() {
   const sidebar = document.getElementById('artist-sidebar');
   const toggle = document.getElementById('artist-sidebar-toggle');
   const clear = document.getElementById('artist-clear');
+  const chipContainer = document.getElementById('active-artist');
+  const chipLabel = chipContainer?.dataset.label || 'Artist';
   const buttons = sidebar?.querySelectorAll('[data-artist]');
   if (!sidebar || !toggle || !buttons) return;
 
@@ -15,6 +17,18 @@ export default function artistFilter() {
       url.searchParams.delete('artist');
     }
     history.replaceState({}, '', url.toString());
+  }
+
+  function renderChip(artist) {
+    if (!chipContainer) return;
+    chipContainer.innerHTML = '';
+    if (!artist) return;
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'tag-pill flex items-center gap-1 text-sm';
+    chip.innerHTML = `${chipLabel}: ${artist} <span aria-hidden="true">&times;</span>`;
+    chip.addEventListener('click', () => activate(''));
+    chipContainer.appendChild(chip);
   }
 
   function activate(artist) {
@@ -31,6 +45,7 @@ export default function artistFilter() {
       localStorage.removeItem(STORAGE_KEY);
     }
     updateURL(artist);
+    renderChip(artist);
     if (window.applySongFilters) {
       window.applySongFilters();
     }


### PR DESCRIPTION
## Summary
- display selected artist as removable chip above song grid
- sync artist filter selection to URL history and localStorage
- document artist filter chip behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c20bb87a888330bf30e250be8152c7