### PR TITLE
feat: add off-canvas filters for small screens

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -23,6 +23,7 @@
       "bpm": "BPM",
       "artist": "Artist",
       "artists": "Artists",
+      "filters": "Filters",
       "noMatches": "No songs match your filters.",
       "clear": "Clear",
       "clearFilters": "Clear filters",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -23,6 +23,7 @@
     "bpm": "BPM",
       "artist": "Artista",
       "artists": "Artistas",
+      "filters": "Filtros",
       "noMatches": "No hay canciones que coincidan con tus filtros.",
       "clear": "Limpiar",
       "clearFilters": "Limpiar filtros",

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -51,29 +51,11 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
     <meta property="og:url" content={url} />
   </Fragment>
   <h1>{t('songs.title')}</h1>
-  <button
-    id="artist-sidebar-toggle"
-    class="mb-4 flex items-center md:hidden"
-    aria-controls="artist-sidebar"
-    aria-expanded="false"
-    type="button"
-  >
-    {t('songs.artists')}
-    <svg
-      class="ml-2 h-4 w-4 transition-transform"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke-width="1.5"
-      stroke="currentColor"
-    >
-      <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-    </svg>
-  </button>
   <div class="md:flex md:gap-4">
     <aside
       id="artist-sidebar"
-      class="mb-4 hidden w-48 shrink-0 md:block"
+      class="fixed inset-y-0 left-0 z-50 w-64 -translate-x-full transform bg-white p-4 transition-transform dark:bg-gray-800 md:static md:mb-4 md:block md:w-48 md:translate-x-0 md:bg-transparent md:p-0 md:shrink-0"
+      aria-hidden="true"
     >
       <div class="mb-2 flex items-center justify-between">
         <h2 class="text-sm font-semibold">{t('songs.artists')}</h2>
@@ -114,14 +96,26 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
         </ul>
       </nav>
     </aside>
+    <div id="artist-overlay" class="fixed inset-0 z-40 bg-black/50 hidden md:hidden"></div>
     <div class="flex-1">
-      <label for="song-search" class="sr-only">{t('songs.searchPlaceholder')}</label>
-      <input
-        id="song-search"
-        type="text"
-        placeholder={t('songs.searchPlaceholder')}
-        class="input mb-2 w-full"
-      />
+      <div class="mb-2 flex gap-2">
+        <label for="song-search" class="sr-only">{t('songs.searchPlaceholder')}</label>
+        <input
+          id="song-search"
+          type="text"
+          placeholder={t('songs.searchPlaceholder')}
+          class="input w-full"
+        />
+        <button
+          id="artist-sidebar-toggle"
+          class="btn-secondary px-3 py-2 text-sm md:hidden"
+          aria-controls="artist-sidebar"
+          aria-expanded="false"
+          type="button"
+        >
+          {t('songs.filters')}
+        </button>
+      </div>
       <p class="mb-4 text-xs text-gray-600 dark:text-gray-400">
         {t('songs.searchTip')}
       </p>
@@ -154,7 +148,7 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
       </p>
       <ul
         id="song-list"
-        class="grid list-none gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3"
+        class="grid list-none gap-4 p-0 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
       >
         {songs.map((song) => {
           const artist = song.entry.data.artist || 'Unknown';

--- a/src/scripts/artistFilter.js
+++ b/src/scripts/artistFilter.js
@@ -3,11 +3,63 @@ const STORAGE_KEY = 'artistFilter';
 export default function artistFilter() {
   const sidebar = document.getElementById('artist-sidebar');
   const toggle = document.getElementById('artist-sidebar-toggle');
+  const overlay = document.getElementById('artist-overlay');
   const clear = document.getElementById('artist-clear');
   const chipContainer = document.getElementById('active-artist');
   const chipLabel = chipContainer?.dataset.label || 'Artist';
   const buttons = sidebar?.querySelectorAll('[data-artist]');
   if (!sidebar || !toggle || !buttons) return;
+
+  if (window.innerWidth >= 768) {
+    sidebar.setAttribute('aria-hidden', 'false');
+  }
+
+  let firstFocusable;
+  let lastFocusable;
+  let previousFocus;
+
+  const focusableSelectors =
+    'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+  function trapFocus(e) {
+    if (e.key === 'Tab') {
+      if (e.shiftKey && document.activeElement === firstFocusable) {
+        e.preventDefault();
+        lastFocusable?.focus();
+      } else if (!e.shiftKey && document.activeElement === lastFocusable) {
+        e.preventDefault();
+        firstFocusable?.focus();
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeSidebar();
+      e.stopPropagation();
+    }
+  }
+
+  function openSidebar() {
+    previousFocus = document.activeElement;
+    toggle.setAttribute('aria-expanded', 'true');
+    sidebar.setAttribute('aria-hidden', 'false');
+    sidebar.classList.remove('-translate-x-full');
+    overlay?.classList.remove('hidden');
+    const focusables = sidebar.querySelectorAll(focusableSelectors);
+    firstFocusable = focusables[0];
+    lastFocusable = focusables[focusables.length - 1];
+    firstFocusable?.focus();
+    document.addEventListener('keydown', trapFocus, true);
+  }
+
+  function closeSidebar() {
+    toggle.setAttribute('aria-expanded', 'false');
+    sidebar.setAttribute('aria-hidden', 'true');
+    sidebar.classList.add('-translate-x-full');
+    overlay?.classList.add('hidden');
+    document.removeEventListener('keydown', trapFocus, true);
+    if (previousFocus instanceof HTMLElement) {
+      previousFocus.focus();
+    }
+  }
 
   function updateURL(artist) {
     const url = new URL(window.location.href);
@@ -64,9 +116,15 @@ export default function artistFilter() {
 
   toggle.addEventListener('click', () => {
     const expanded = toggle.getAttribute('aria-expanded') === 'true';
-    toggle.setAttribute('aria-expanded', String(!expanded));
-    sidebar.classList.toggle('hidden', expanded);
-    toggle.querySelector('svg')?.classList.toggle('rotate-180', !expanded);
+    if (expanded) {
+      closeSidebar();
+    } else {
+      openSidebar();
+    }
+  });
+
+  overlay?.addEventListener('click', () => {
+    closeSidebar();
   });
 
   let selected = new URLSearchParams(window.location.search).get('artist');


### PR DESCRIPTION
## Summary
- Switch sidebar to an off-canvas panel triggered by a new Filters button and overlay
- Trap focus within the sidebar and close with overlay click or Escape
- Limit song grid to 1–2 columns on small screens and add translations for Filters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c20e074cd08330aad5fcd99330363c