### PR TITLE
style: refine song list pills and layout

### DIFF
--- a/src/pages/songs/[slug].astro
+++ b/src/pages/songs/[slug].astro
@@ -82,7 +82,7 @@ const description = t('songs.chartFor', { title: song.data.title });
   </header>
   <Content />
   {pdf && (
-    <div class="mt-8 flex gap-4">
+    <div class="not-prose mt-8 flex gap-4">
       <a href={pdf} download class="btn-primary">{t('songs.downloadPdf')}</a>
       <a href={pdf} target="_blank" class="btn-secondary">{t('songs.openPdf')}</a>
     </div>

--- a/src/pages/songs/[slug].astro
+++ b/src/pages/songs/[slug].astro
@@ -68,7 +68,7 @@ const description = t('songs.chartFor', { title: song.data.title });
     {song.data.tags && (
       <div class="mt-2 flex flex-wrap gap-2">
         {song.data.tags.map((tag) => (
-          <span class="tag-pill">{tag}</span>
+          <span class="pill bg-gray-200 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-200">{tag}</span>
         ))}
       </div>
     )}

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -202,7 +202,7 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
             >
               <a
                 href={`${base}${song.linkLocale === 'en' ? 'en/' : ''}songs/${song.slug}/`}
-                class="card block"
+                class="card"
               >
                 <h2 class="text-lg font-semibold">{song.entry.data.title}</h2>
                 {song.entry.data.artist && (

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -86,12 +86,12 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
               type="button"
               data-artist=""
               aria-pressed={initialArtist ? 'false' : 'true'}
-              class={`flex w-full items-center justify-between rounded-full px-3 py-1 text-sm ${
+              class={`pill flex w-full items-center justify-between px-3 py-1 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 ${
                 initialArtist ? '' : 'bg-gray-200 dark:bg-gray-700'
               }`}
             >
               <span>{t('songs.all')}</span>
-              <span class="text-xs text-gray-600 dark:text-gray-400">{songs.length}</span>
+              <span class="count-badge">{songs.length}</span>
             </button>
           </li>
           {artists.map(([name, count]) => (
@@ -100,12 +100,12 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
                 type="button"
                 data-artist={name}
                 aria-pressed={initialArtist === name ? 'true' : 'false'}
-                class={`flex w-full items-center justify-between rounded-full px-3 py-1 text-sm ${
+                class={`pill flex w-full items-center justify-between px-3 py-1 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 ${
                   initialArtist === name ? 'bg-gray-200 dark:bg-gray-700' : ''
                 }`}
               >
                 <span>{name}</span>
-                <span class="text-xs text-gray-600 dark:text-gray-400">{count}</span>
+                <span class="count-badge">{count}</span>
               </button>
             </li>
           ))}
@@ -146,14 +146,14 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
               type="button"
               data-tag={tag.toLowerCase()}
               aria-pressed={initialTag === tag.toLowerCase() ? 'true' : 'false'}
-              class={`tag-pill flex items-center gap-1 px-3 py-1 text-sm ${
+              class={`pill flex items-center gap-1 px-3 py-1 text-sm bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 ${
                 initialTag === tag.toLowerCase()
                   ? 'bg-primary text-white dark:bg-primary dark:text-white'
                   : ''
               }`}
             >
               <span>{tag}</span>
-              <span class="text-xs text-gray-600 dark:text-gray-400">({count})</span>
+              <span class="count-badge">{count}</span>
             </button>
           ))}
         </div>
@@ -162,7 +162,7 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
         {initialArtist && (
           <button
             type="button"
-            class="tag-pill flex items-center gap-1 text-sm"
+            class="pill flex items-center gap-1 px-3 py-1 text-sm bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
           >
             {t('songs.artist')}: {initialArtist} <span aria-hidden="true">&times;</span>
           </button>
@@ -178,7 +178,7 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
       </p>
       <ul
         id="song-list"
-        class="grid list-none gap-4 p-0 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+        class="grid list-none gap-5 p-0 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
       >
         {songs.map((song) => {
           const artist = song.entry.data.artist || 'Unknown';
@@ -216,7 +216,7 @@ const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
                 {song.entry.data.tags && (
                   <ul class="mt-2 flex flex-wrap gap-1 list-none p-0">
                     {song.entry.data.tags.map((tag) => (
-                      <li class="tag-pill">{tag}</li>
+                      <li class="pill bg-gray-200 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-200">{tag}</li>
                     ))}
                   </ul>
                 )}

--- a/src/scripts/artistFilter.js
+++ b/src/scripts/artistFilter.js
@@ -77,7 +77,7 @@ export default function artistFilter() {
     if (!artist) return;
     const chip = document.createElement('button');
     chip.type = 'button';
-    chip.className = 'tag-pill flex items-center gap-1 text-sm';
+    chip.className = 'pill flex items-center gap-1 px-3 py-1 text-sm bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200';
     chip.innerHTML = `${chipLabel}: ${artist} <span aria-hidden="true">&times;</span>`;
     chip.addEventListener('click', () => activate(''));
     chipContainer.appendChild(chip);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,11 +9,14 @@
   .btn-secondary {
     @apply inline-block rounded border border-gray-300 bg-white px-4 py-2 text-gray-900 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100;
   }
-  .tag-pill {
-    @apply inline-block rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:bg-gray-700 dark:text-gray-200;
+  .pill {
+    @apply inline-flex items-center rounded-full transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary;
+  }
+  .count-badge {
+    @apply ml-2 rounded-full bg-gray-300 px-2 py-0.5 font-mono tabular-nums text-xs leading-none text-gray-700 dark:bg-gray-600 dark:text-gray-200;
   }
   .card {
-    @apply rounded border border-gray-200 bg-white p-4 transition hover:bg-gray-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700/50;
+    @apply rounded border border-gray-200 bg-white p-3 transition hover:bg-gray-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700/50 sm:p-4;
   }
   .input {
     @apply rounded border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,10 +4,10 @@
 
 @layer components {
   .btn-primary {
-    @apply inline-block rounded bg-primary px-4 py-2 font-semibold text-white hover:bg-primary/90 dark:hover:bg-primary/80;
+    @apply inline-block rounded bg-primary px-4 py-2 font-semibold text-white no-underline hover:bg-primary/90 hover:text-white visited:text-white dark:hover:bg-primary/80 dark:hover:text-white dark:visited:text-white;
   }
   .btn-secondary {
-    @apply inline-block rounded border border-gray-300 bg-white px-4 py-2 text-gray-900 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100;
+    @apply inline-block rounded border border-gray-300 bg-white px-4 py-2 text-gray-900 no-underline hover:bg-gray-50 hover:text-gray-900 visited:text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600 dark:hover:text-gray-100 dark:visited:text-gray-100;
   }
   .pill {
     @apply inline-flex items-center rounded-full transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary;
@@ -16,7 +16,7 @@
     @apply ml-2 rounded-full bg-gray-300 px-2 py-0.5 font-mono tabular-nums text-xs leading-none text-gray-700 dark:bg-gray-600 dark:text-gray-200;
   }
   .card {
-    @apply rounded border border-gray-200 bg-white p-3 transition hover:bg-gray-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700/50 sm:p-4;
+    @apply block rounded border border-gray-200 bg-white p-3 text-inherit no-underline transition hover:bg-gray-50 hover:shadow-sm hover:text-inherit visited:text-inherit focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700/50 dark:hover:text-inherit dark:visited:text-inherit sm:p-4;
   }
   .input {
     @apply rounded border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100;


### PR DESCRIPTION
## Summary
- add reusable `pill` and `count-badge` styles
- improve song sidebar interactions and tag chips
- tighten card spacing and grid gap for mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c21a3399a483308113d75cb1d3559d