### PR TITLE
feat: add content bundle fetch script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+CONTENT_OWNER=acwilan
+CONTENT_REPO=chords-content
+CONTENT_VERSION=v0.1.0
+CONTENT_FILENAME=content.zip
+CONTENT_SHA256=   # optional, leave blank

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,10 @@ node_modules
 # environment
 .env
 .env.*
+!.env.example
 
+# external content
+public/charts/**
+src/content/songs/**
+!public/charts/.keep
+!src/content/songs/.keep

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ This repository hosts the source code for the chords site.
 - GitHub repository: `acwilan/chords`
 - Published site: https://acwilan.github.io/chords
 
+## External Content
+
+Song metadata and charts can be fetched from an external bundle. Copy `.env.example` to `.env` and adjust variables if necessary.
+
+Run `npm run content:fetch` to download the bundle and populate `src/content/songs` and `public/charts`.
+Use `npm run content:clean` to remove fetched files.
+
+
 ## Adding new songs
 
 1. Add an `.md` file in `src/content/songs/` with the song's frontmatter.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "changelog": "standard-version --skip.tag",
-    "release": "standard-version"
+    "release": "standard-version",
+    "content:fetch": "bash scripts/fetch-content.sh",
+    "content:clean": "rm -rf tmp && git clean -fdX src/content/songs public/charts"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/scripts/fetch-content.sh
+++ b/scripts/fetch-content.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -f ".env" ]; then
+  set -o allexport
+  source .env
+  set +o allexport
+fi
+
+CONTENT_OWNER="${CONTENT_OWNER:-acwilan}"
+CONTENT_REPO="${CONTENT_REPO:-chords-content}"
+CONTENT_VERSION="${CONTENT_VERSION:-v0.1.0}"
+CONTENT_FILENAME="${CONTENT_FILENAME:-content.zip}"
+CONTENT_SHA256="${CONTENT_SHA256:-}"
+
+URL="https://github.com/${CONTENT_OWNER}/${CONTENT_REPO}/releases/download/${CONTENT_VERSION}/${CONTENT_FILENAME}"
+
+mkdir -p tmp
+echo "Downloading $URL"
+curl -L "$URL" -o tmp/content.zip
+
+if [ -n "$CONTENT_SHA256" ]; then
+  echo "Verifying checksum..."
+  if [[ "$CONTENT_SHA256" == *" "* ]]; then
+    echo "$CONTENT_SHA256" | (cd tmp && shasum -a 256 -c -)
+  else
+    echo "$CONTENT_SHA256  content.zip" | (cd tmp && shasum -a 256 -c -)
+  fi
+fi
+
+rm -rf tmp/content
+unzip -q tmp/content.zip -d tmp/content
+
+mkdir -p src/content/songs public/charts
+
+if [ -d tmp/content/songs ]; then
+  rsync -a --delete --exclude '.keep' tmp/content/songs/ src/content/songs/
+fi
+if [ -d tmp/content/pdfs ]; then
+  rsync -a --delete --exclude '.keep' tmp/content/pdfs/ public/charts/
+fi
+
+song_count=$(find src/content/songs -type f ! -name '.keep' | wc -l | tr -d ' ')
+pdf_count=$(find public/charts -type f ! -name '.keep' | wc -l | tr -d ' ')
+echo "Fetched ${song_count} songs and ${pdf_count} pdfs."


### PR DESCRIPTION
## Summary
- add `.env.example` and gitignore rules for external content
- add `fetch-content.sh` script to download content bundle
- document and expose content bundle scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2efe02ec48330bff724734815e467