### PR TITLE
ci: fetch content bundle before Pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CONTENT_OWNER: ${{ vars.CONTENT_OWNER || 'acwilan' }}
+      CONTENT_REPO: ${{ vars.CONTENT_REPO || 'chords-content' }}
+      CONTENT_VERSION: ${{ vars.CONTENT_VERSION || 'v0.1.0' }}
+      CONTENT_FILENAME: ${{ vars.CONTENT_FILENAME || 'content.zip' }}
+      CONTENT_SHA256: ${{ vars.CONTENT_SHA256 || '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,6 +30,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm test
+      - name: Fetch content bundle
+        run: npm run content:fetch
       - run: npm run build
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ This repository hosts the source code for the chords site.
 
 Song metadata and charts can be fetched from an external bundle. Copy `.env.example` to `.env` and adjust variables if necessary.
 
+Forks should set repository Variables so the workflow can fetch their own release:
+
+- `CONTENT_OWNER`
+- `CONTENT_REPO`
+- `CONTENT_VERSION`
+- `CONTENT_FILENAME`
+- `CONTENT_SHA256` (optional)
+
 Run `npm run content:fetch` to download the bundle and populate `src/content/songs` and `public/charts`.
 Use `npm run content:clean` to remove fetched files.
 


### PR DESCRIPTION
## Summary
- fetch content bundle before building site
- document repo variables for forked content releases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2f16307508330a4ec57197b9df33b