### PR TITLE
feat: normalize pdf frontmatter paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Use `npm run content:clean` to remove fetched files.
 
 1. Add an `.md` file in `src/content/songs/` with the song's frontmatter.
 2. Provide `slug`, `lang` (`es` or `en`), `title` and optional fields like `key`, `bpm`, `artist`, `author`, `tags` and `pdf`.
+   The `pdf` value may be just the filename (`Mi-Cancion.pdf`), an absolute path (`/charts/Mi-Cancion.pdf`),
+   or a path including the normalized artist name (`/charts/sixpence-none-the-richer/Kiss-Me.pdf`).
    The `artist` field is used to build the artist filter on the songs page.
-3. Place the PDF chart in `public/charts/` with the same name referenced in the frontmatter.
+3. Place the PDF chart in `public/charts/` matching the path or filename used in the `pdf` field.
 
 ## Localization
 

--- a/src/pages/songs/[slug].astro
+++ b/src/pages/songs/[slug].astro
@@ -2,6 +2,7 @@
 import App from '../../layouts/App.astro';
 import { getCollection } from 'astro:content';
 import { getLocaleFromUrl, createT } from '../../utils/i18n';
+import { pdfPath } from '../../utils/pdfPath';
 
 export async function getStaticPaths() {
   const songs = await getCollection('songs');
@@ -32,11 +33,9 @@ const otherLink = otherEntry
   : undefined;
 const otherLangName = otherLocale === 'en' ? 'English' : 'Español';
 const { Content } = await song.render();
+const rawPdf = song.data.pdf && pdfPath(song.data.pdf);
 const pdf =
-  song.data.pdf &&
-  (song.data.pdf.startsWith('http')
-    ? song.data.pdf
-    : `${base}${song.data.pdf.replace(/^\//, '')}`);
+  rawPdf && (rawPdf.startsWith('http') ? rawPdf : `${base}${rawPdf.replace(/^\//, '')}`);
 const url = `${base}${locale === 'en' ? 'en/' : ''}songs/${slug}/`;
 const description = t('songs.chartFor', { title: song.data.title });
 ---

--- a/src/utils/pdfPath.test.ts
+++ b/src/utils/pdfPath.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { pdfPath } from './pdfPath';
+
+describe('pdfPath', () => {
+  it('prefixes bare filenames with /charts/', () => {
+    expect(pdfPath('Mi-Cancion.pdf')).toBe('/charts/Mi-Cancion.pdf');
+  });
+
+  it('passes through absolute paths', () => {
+    expect(pdfPath('/charts/Mi-Cancion.pdf')).toBe('/charts/Mi-Cancion.pdf');
+  });
+
+  it('passes through artist-scoped paths', () => {
+    expect(pdfPath('/charts/sixpence-none-the-richer/Kiss-Me.pdf')).toBe(
+      '/charts/sixpence-none-the-richer/Kiss-Me.pdf',
+    );
+  });
+
+  it('passes through external URLs', () => {
+    expect(pdfPath('https://example.com/test.pdf')).toBe(
+      'https://example.com/test.pdf',
+    );
+  });
+});

--- a/src/utils/pdfPath.ts
+++ b/src/utils/pdfPath.ts
@@ -1,0 +1,9 @@
+export function pdfPath(pdf: string): string {
+  if (pdf.startsWith('http')) {
+    return pdf;
+  }
+  if (pdf.startsWith('/')) {
+    return pdf;
+  }
+  return `/charts/${pdf}`;
+}


### PR DESCRIPTION
## Summary
- allow bare pdf filenames by normalizing to `/charts/<name>`
- use pdfPath helper on song detail page
- document pdf path options in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3009fe6e4833097e229d0fc2e5de4