### PR TITLE
chore: parameterize release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version to release (semver or major/minor/patch)'
+        required: true
+        default: patch
 
 permissions:
   contents: write
@@ -24,7 +29,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - run: npm run release
+      - run: npm run release -- -r ${{ inputs.release_version }}
       - name: Get release version
         run: |
           version=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary
- allow specifying release version via workflow dispatch input
- pass release version to standard-version before branch and PR creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c355267e488330acb40570c03e016b