### PR TITLE
feat: enhance SEO with canonical routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Use `npm run content:clean` to remove fetched files.
 ## Adding new songs
 
 1. Add an `.md` file in `src/content/songs/` with the song's frontmatter.
-2. Provide `slug`, `lang` (`es` or `en`), `title` and optional fields like `key`, `bpm`, `artist`, `author`, `tags` and `pdf`.
+2. Provide `slug`, `lang` (`es` or `en`), `title` and optional fields like `key`, `bpm`, `artist`, `author`, `tags`, `pdf`, and `seoKeywords`.
    The `pdf` value may be just the filename (`Mi-Cancion.pdf`), an absolute path (`/charts/Mi-Cancion.pdf`),
    or a path including the normalized artist name (`/charts/sixpence-none-the-richer/Kiss-Me.pdf`).
    The `artist` field is used to build the artist filter on the songs page.
@@ -42,6 +42,12 @@ Use `npm run content:clean` to remove fetched files.
 
 - `artist` and `author` are optional metadata fields.
 - `capo` is no longer supported.
+
+## SEO
+
+- Each song has a canonical route at `/songs/{slug}/`. Keyword aliases (`/songs/{slug}/chords`, `/songs/{slug}/acordes`, `/songs/{slug}/cifrados`) render the same content but set `rel="canonical"` to the base route. Only canonical URLs appear in `sitemap.xml`.
+- Add optional `seoKeywords` in a song's frontmatter to append custom keywords to the defaults (`chords`, `acordes`, `cifrados`, artist, key).
+- Alias routes exist solely for discoverability and are excluded from the sitemap.
 
 ## Artist filter
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,14 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
+import sitemap from '@astrojs/sitemap';
 // https://docs.astro.build/en/reference/configuration-reference/
 export default defineConfig({
   site: "https://acwilan.github.io",
   base: '/chordbook',
-  integrations: [tailwind()],
+  integrations: [
+    tailwind(),
+    sitemap({
+      filter: (page) => !/(\/((chords)|(acordes)|(cifrados))\/?)$/.test(page),
+    }),
+  ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chordbook",
       "version": "1.0.0",
       "devDependencies": {
+        "@astrojs/sitemap": "^3.0.0",
         "@astrojs/tailwind": "^5.0.0",
         "@tailwindcss/typography": "^0.5.10",
         "@testing-library/dom": "^10.4.1",
@@ -117,6 +118,18 @@
       },
       "engines": {
         "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.5.1.tgz",
+      "integrity": "sha512-uX5z52GLtQTgOe8r3jeGmFRYrFe52mdpLYJzqjvL1cdy5Kg3MLOZEvaZ/OCH0fSq0t7e50uJQ6oBMZG0ffszBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^8.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^3.24.4"
       }
     },
     "node_modules/@astrojs/tailwind": {
@@ -2167,12 +2180,32 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -8155,6 +8188,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -8311,6 +8351,33 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sitemap": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.0.tgz",
+      "integrity": "sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8599,6 +8666,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -9196,6 +9270,13 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@astrojs/tailwind": "^5.0.0",
+    "@astrojs/sitemap": "^3.0.0",
     "@tailwindcss/typography": "^0.5.10",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://acwilan.github.io/chordbook/sitemap.xml

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -4,12 +4,14 @@ const songs = defineCollection({
   schema: z.object({
     lang: z.enum(['es', 'en']).default('es'),
     title: z.string(),
+    slug: z.string().optional(),
     key: z.string().optional(),
     bpm: z.number().optional(),
     artist: z.string().optional(),
     author: z.string().optional(),
     tags: z.array(z.string()).optional(),
     pdf: z.string().optional(),
+    seoKeywords: z.array(z.string()).optional(),
   }),
 });
 

--- a/src/pages/en/songs/[slug].astro
+++ b/src/pages/en/songs/[slug].astro
@@ -1,5 +1,0 @@
----
-import SongPage, { getStaticPaths } from '../../songs/[slug].astro';
-export { getStaticPaths };
----
-<SongPage />

--- a/src/pages/en/songs/[slug]/chords.astro
+++ b/src/pages/en/songs/[slug]/chords.astro
@@ -1,0 +1,5 @@
+---
+import SongPage, { getStaticPaths } from '../../../songs/[slug]/index.astro';
+export { getStaticPaths };
+---
+<SongPage />

--- a/src/pages/en/songs/[slug]/index.astro
+++ b/src/pages/en/songs/[slug]/index.astro
@@ -1,0 +1,5 @@
+---
+import SongPage, { getStaticPaths } from '../../../songs/[slug]/index.astro';
+export { getStaticPaths };
+---
+<SongPage />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import App from '../layouts/App.astro';
 import { getLocaleFromUrl, createT } from '../utils/i18n';
+import { buildSeo } from '../utils/seo';
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
@@ -8,16 +9,34 @@ const base = import.meta.env.BASE_URL.endsWith('/')
 const locale = getLocaleFromUrl(Astro.url.pathname, base);
 const t = createT(locale);
 const description = t('home.intro');
-const url = locale === 'en' ? `${base}en/` : base;
+const site = Astro.site ? Astro.site.toString().replace(/\/$/, '') : '';
+const url = locale === 'en' ? `${site}${base}en/` : `${site}${base}`;
+const alternate = { en: `${site}${base}en/`, es: `${site}${base}` };
+const seo = buildSeo({
+  title: t('site.title'),
+  description,
+  url,
+  locale,
+  alternate,
+});
 ---
 <App>
   <Fragment slot="head">
-    <title>{t('site.title')}</title>
-    <meta name="description" content={description} />
-    <meta property="og:title" content={t('site.title')} />
-    <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content={url} />
+    <title>{seo.title}</title>
+    <meta name="description" content={seo.description} />
+    <meta property="og:title" content={seo.title} />
+    <meta property="og:description" content={seo.description} />
+    <meta property="og:type" content={seo.type} />
+    <meta property="og:url" content={seo.url} />
+    <meta property="og:site_name" content="ChordBook" />
+    <meta property="og:locale" content={seo.locale} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={seo.title} />
+    <meta name="twitter:description" content={seo.description} />
+    <link rel="canonical" href={seo.url} />
+    {Object.entries(seo.alternate).map(([lang, href]) => (
+      <link rel="alternate" hreflang={lang} href={href} />
+    ))}
   </Fragment>
   <section class="not-prose flex min-h-[60vh] flex-col items-center justify-center py-24 text-center">
     <h1 class="text-5xl font-bold">{t('site.title')}</h1>

--- a/src/pages/songs/[slug]/acordes.astro
+++ b/src/pages/songs/[slug]/acordes.astro
@@ -1,0 +1,5 @@
+---
+import SongPage, { getStaticPaths } from './index.astro';
+export { getStaticPaths };
+---
+<SongPage />

--- a/src/pages/songs/[slug]/chords.astro
+++ b/src/pages/songs/[slug]/chords.astro
@@ -1,0 +1,5 @@
+---
+import SongPage, { getStaticPaths } from './index.astro';
+export { getStaticPaths };
+---
+<SongPage />

--- a/src/pages/songs/[slug]/cifrados.astro
+++ b/src/pages/songs/[slug]/cifrados.astro
@@ -1,0 +1,5 @@
+---
+import SongPage, { getStaticPaths } from './index.astro';
+export { getStaticPaths };
+---
+<SongPage />

--- a/src/pages/songs/[slug]/index.astro
+++ b/src/pages/songs/[slug]/index.astro
@@ -1,13 +1,15 @@
 ---
-import App from '../../layouts/App.astro';
+import App from '../../../layouts/App.astro';
 import { getCollection } from 'astro:content';
-import { getLocaleFromUrl, createT } from '../../utils/i18n';
-import { pdfPath } from '../../utils/pdfPath';
+import { getLocaleFromUrl, createT, type Locale } from '../../../utils/i18n';
+import { pdfPath } from '../../../utils/pdfPath';
+import { buildSeo, songJsonLd } from '../../../utils/seo';
+import { buildSongUrls, slugify } from '../../../utils/urls';
 
 export async function getStaticPaths() {
   const songs = await getCollection('songs');
   const slugs = Array.from(
-    new Set(songs.map((s) => s.id.replace(/(\.(en|es))?\.md$/, '')))
+    new Set(songs.map((s) => s.data.slug || slugify(s.data.title)))
   );
   return slugs.map((slug) => ({ params: { slug } }));
 }
@@ -19,14 +21,13 @@ const locale = getLocaleFromUrl(Astro.url.pathname, base);
 const t = createT(locale);
 const slug = Astro.params.slug;
 const songs = await getCollection('songs');
-const entries = songs.filter(
-  (s) => s.id.replace(/(\.(en|es))?\.md$/, '') === slug
-);
+const getSlug = (s: any) => s.data.slug || slugify(s.data.title);
+const entries = songs.filter((s) => getSlug(s) === slug);
 if (entries.length === 0) {
   throw new Error(`Song not found: ${slug}`);
 }
 const song = entries.find((e) => e.data.lang === locale) || entries[0];
-const otherLocale = locale === 'en' ? 'es' : 'en';
+const otherLocale: Locale = locale === 'en' ? 'es' : 'en';
 const otherEntry = entries.find((e) => e.data.lang === otherLocale);
 const otherLink = otherEntry
   ? `${base}${otherLocale === 'en' ? 'en/' : ''}songs/${slug}/`
@@ -36,17 +37,55 @@ const { Content } = await song.render();
 const rawPdf = song.data.pdf && pdfPath(song.data.pdf);
 const pdf =
   rawPdf && (rawPdf.startsWith('http') ? rawPdf : `${base}${rawPdf.replace(/^\//, '')}`);
-const url = `${base}${locale === 'en' ? 'en/' : ''}songs/${slug}/`;
-const description = t('songs.chartFor', { title: song.data.title });
+const site = Astro.site ? Astro.site.toString().replace(/\/$/, '') : '';
+const urls = buildSongUrls({ site, base, locale, slug });
+const availableLocales = entries.map((e) => e.data.lang as Locale);
+const alternate: Record<string, string> = {};
+for (const loc of availableLocales) {
+  alternate[loc] = buildSongUrls({ site, base, locale: loc, slug }).canonical;
+}
+const seo = buildSeo({
+  title: song.data.title,
+  artist: song.data.artist,
+  key: song.data.key,
+  seoKeywords: song.data.seoKeywords,
+  url: urls.canonical,
+  locale,
+  type: 'article',
+  alternate,
+});
+const jsonLd = songJsonLd({
+  title: song.data.title,
+  artist: song.data.artist,
+  author: song.data.author,
+  locale,
+  keywords: seo.keywords,
+  url: urls.canonical,
+  pdf,
+  site,
+  base,
+  slug,
+});
 ---
 <App>
   <Fragment slot="head">
-    <title>{song.data.title}</title>
-    <meta name="description" content={description} />
-    <meta property="og:title" content={song.data.title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content={url} />
+    <title>{seo.title}</title>
+    <meta name="description" content={seo.description} />
+    <meta name="keywords" content={seo.keywords.join(', ')} />
+    <meta property="og:title" content={seo.title} />
+    <meta property="og:description" content={seo.description} />
+    <meta property="og:type" content={seo.type} />
+    <meta property="og:url" content={seo.url} />
+    <meta property="og:site_name" content="ChordBook" />
+    <meta property="og:locale" content={seo.locale} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={seo.title} />
+    <meta name="twitter:description" content={seo.description} />
+    <link rel="canonical" href={seo.url} />
+    {Object.entries(seo.alternate).map(([lang, href]) => (
+      <link rel="alternate" hreflang={lang} href={href} />
+    ))}
+    <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
   </Fragment>
   <header class="mb-8 border-b pb-4">
     <h1 class="mb-2 text-3xl font-bold">{song.data.title}</h1>

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -260,10 +260,14 @@ const seo = buildSeo({
     </div>
   </div>
   {initialArtist && (
-    <script is:inline>window.activeArtist = {JSON.stringify(initialArtist)};</script>
+    <script is:inline>
+      window.activeArtist = ${JSON.stringify(initialArtist)};
+    </script>
   )}
   {initialTag && (
-    <script is:inline>window.activeTag = {JSON.stringify(initialTag)};</script>
+    <script is:inline>
+      window.activeTag = ${JSON.stringify(initialTag)};
+    </script>
   )}
   <script id="artist-data" type="application/json">
     {JSON.stringify(artists)}

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -3,6 +3,8 @@ import App from '../../layouts/App.astro';
 import { getCollection } from 'astro:content';
 import { getLocaleFromUrl, createT } from '../../utils/i18n';
 import artistFilterScript from '../../scripts/artistFilter.js?url';
+import { buildSeo } from '../../utils/seo';
+import { slugify } from '../../utils/urls';
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
@@ -12,7 +14,7 @@ const t = createT(locale);
 const all = await getCollection('songs');
 const map = new Map();
 for (const entry of all) {
-  const baseSlug = entry.id.replace(/(\.(en|es))?\.md$/, '');
+  const baseSlug = entry.data.slug || slugify(entry.data.title);
   const lang = entry.data.lang;
   const group = map.get(baseSlug) || {};
   group[lang] = entry;
@@ -51,16 +53,34 @@ const initialCount = songs.filter((song) => {
   return matchesArtist && matchesTag;
 }).length;
 const description = t('songs.description');
-const url = `${base}${locale === 'en' ? 'en/' : ''}songs/`;
+const site = Astro.site ? Astro.site.toString().replace(/\/$/, '') : '';
+const url = `${site}${base}${locale === 'en' ? 'en/' : ''}songs/`;
+const alternate = { en: `${site}${base}en/songs/`, es: `${site}${base}songs/` };
+const seo = buildSeo({
+  title: t('songs.title'),
+  description,
+  url,
+  locale,
+  alternate,
+});
 ---
 <App>
   <Fragment slot="head">
-    <title>{t('songs.title')}</title>
-    <meta name="description" content={description} />
-    <meta property="og:title" content={t('songs.title')} />
-    <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content={url} />
+    <title>{seo.title}</title>
+    <meta name="description" content={seo.description} />
+    <meta property="og:title" content={seo.title} />
+    <meta property="og:description" content={seo.description} />
+    <meta property="og:type" content={seo.type} />
+    <meta property="og:url" content={seo.url} />
+    <meta property="og:site_name" content="ChordBook" />
+    <meta property="og:locale" content={seo.locale} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={seo.title} />
+    <meta name="twitter:description" content={seo.description} />
+    <link rel="canonical" href={seo.url} />
+    {Object.entries(seo.alternate).map(([lang, href]) => (
+      <link rel="alternate" hreflang={lang} href={href} />
+    ))}
   </Fragment>
   <h1>{t('songs.title')}</h1>
   <div class="md:flex md:gap-4">

--- a/src/utils/seo.test.ts
+++ b/src/utils/seo.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { buildSeo } from './seo';
+import { buildSongUrls } from './urls';
+
+describe('seo utils', () => {
+  it('builds title and description', () => {
+    const seo = buildSeo({
+      url: 'https://example.com/app/songs/mi-cancion/',
+      locale: 'es',
+      title: 'Mi Canción',
+      artist: 'Artista',
+      key: 'C',
+    });
+    expect(seo.title).toBe('Mi Canción — Artista | ChordBook');
+    expect(seo.description).toContain('Mi Canción');
+    expect(seo.description).toContain('Artista');
+    expect(seo.description).toContain('PDF');
+  });
+
+  it('builds canonical and hreflang', () => {
+    const urls = buildSongUrls({
+      site: 'https://example.com',
+      base: '/app',
+      locale: 'es',
+      slug: 'test',
+    });
+    expect(urls.canonical).toBe('https://example.com/app/songs/test/');
+    expect(urls.hrefLang.en).toBe('https://example.com/app/en/songs/test/');
+  });
+});

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,0 +1,108 @@
+import type { Locale } from './i18n';
+interface SeoOptions {
+  title: string;
+  url: string;
+  locale: Locale;
+  artist?: string;
+  key?: string;
+  description?: string;
+  type?: 'article' | 'website';
+  seoKeywords?: string[];
+  alternate?: Record<string, string>;
+}
+
+export function buildSeo(opts: SeoOptions) {
+  const title = opts.artist
+    ? `${opts.title} — ${opts.artist} | ChordBook`
+    : `${opts.title} | ChordBook`;
+  const description =
+    opts.description ??
+    `${opts.title}${opts.artist ? ` by ${opts.artist}` : ''}$${
+      opts.key ? ` in ${opts.key}` : ''
+    }. PDF chord chart available.`.replace('$', '');
+  const keywords = Array.from(
+    new Set(
+      [
+        'chords',
+        'acordes',
+        'cifrados',
+        opts.artist,
+        opts.key,
+        ...(opts.seoKeywords ?? []),
+      ].filter(Boolean) as string[],
+    ),
+  );
+  return {
+    title,
+    description,
+    keywords,
+    url: opts.url,
+    alternate: opts.alternate ?? {},
+    type: opts.type ?? 'website',
+    locale: opts.locale,
+  };
+}
+
+export function songJsonLd(params: {
+  title: string;
+  artist?: string;
+  author?: string;
+  locale: Locale;
+  keywords: string[];
+  url: string;
+  pdf?: string;
+  site: string;
+  base: string;
+  slug: string;
+}) {
+  const { title, artist, author, locale, keywords, url, pdf, site, base, slug } = params;
+  const basePath = base.endsWith('/') ? base : `${base}/`;
+  const home = `${site}${basePath}${locale === 'en' ? 'en/' : ''}`;
+  const songs = `${home}songs/`;
+  const data: any = {
+    '@context': 'https://schema.org',
+    '@type': 'MusicComposition',
+    name: title,
+    inLanguage: locale,
+    keywords,
+    isAccessibleForFree: true,
+    url,
+    breadcrumb: {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Home',
+          item: home,
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Songs',
+          item: songs,
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: title,
+          item: url,
+        },
+      ],
+    },
+  };
+  if (artist) data.byArtist = artist;
+  if (author) {
+    data.composer = author;
+    data.lyricist = author;
+  }
+  if (pdf) {
+    data.encoding = {
+      '@type': 'MediaObject',
+      fileFormat: 'application/pdf',
+      contentUrl: pdf,
+      name: `${title} — Chord chart (PDF)`,
+    };
+  }
+  return data;
+}

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,0 +1,36 @@
+import type { Locale } from './i18n';
+
+export interface SongUrlOptions {
+  site: string;
+  base: string;
+  locale: Locale;
+  slug: string;
+}
+
+function joinBase(base: string): string {
+  return base.endsWith('/') ? base : `${base}/`;
+}
+
+export function buildSongUrls({ site, base, locale, slug }: SongUrlOptions) {
+  const basePath = joinBase(base);
+  const localePath = locale === 'en' ? 'en/' : '';
+  const path = `${basePath}${localePath}songs/${slug}/`;
+  const canonical = `${site.replace(/\/$/, '')}${path}`;
+  return {
+    canonical,
+    chords: `${canonical}chords/`,
+    acordes: `${canonical}acordes/`,
+    cifrados: `${canonical}cifrados/`,
+    hrefLang: {
+      en: `${site.replace(/\/$/, '')}${basePath}en/songs/${slug}/`,
+      es: `${site.replace(/\/$/, '')}${basePath}songs/${slug}/`,
+    },
+  } as const;
+}
+
+export function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}


### PR DESCRIPTION
## Summary
- add SEO and URL helpers with JSON-LD support
- serve song pages with canonical URLs and keyword aliases
- wire up sitemap and robots.txt

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c38ba6e2b08330aeb15268e47cd188