### PR TITLE
Fix build failure due to slug field in content schema

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,18 +1,21 @@
 import { defineCollection, z } from 'astro:content';
+import { slugify } from '../utils/urls';
 
 const songs = defineCollection({
-  schema: z.object({
-    lang: z.enum(['es', 'en']).default('es'),
-    title: z.string(),
-    slug: z.string().optional(),
-    key: z.string().optional(),
-    bpm: z.number().optional(),
-    artist: z.string().optional(),
-    author: z.string().optional(),
-    tags: z.array(z.string()).optional(),
-    pdf: z.string().optional(),
-    seoKeywords: z.array(z.string()).optional(),
-  }),
+  schema: z
+    .object({
+      lang: z.enum(['es', 'en']).default('es'),
+      title: z.string(),
+      key: z.string().optional(),
+      bpm: z.number().optional(),
+      artist: z.string().optional(),
+      author: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+      pdf: z.string().optional(),
+      seoKeywords: z.array(z.string()).optional(),
+    })
+    .passthrough(),
+  slug: ({ data }) => slugify((data as any).slug ?? data.title),
 });
 
 export const collections = { songs };

--- a/src/pages/songs/[slug]/index.astro
+++ b/src/pages/songs/[slug]/index.astro
@@ -4,13 +4,11 @@ import { getCollection } from 'astro:content';
 import { getLocaleFromUrl, createT, type Locale } from '../../../utils/i18n';
 import { pdfPath } from '../../../utils/pdfPath';
 import { buildSeo, songJsonLd } from '../../../utils/seo';
-import { buildSongUrls, slugify } from '../../../utils/urls';
+import { buildSongUrls } from '../../../utils/urls';
 
 export async function getStaticPaths() {
   const songs = await getCollection('songs');
-  const slugs = Array.from(
-    new Set(songs.map((s) => s.data.slug || slugify(s.data.title)))
-  );
+  const slugs = Array.from(new Set(songs.map((s) => s.slug)));
   return slugs.map((slug) => ({ params: { slug } }));
 }
 
@@ -21,8 +19,7 @@ const locale = getLocaleFromUrl(Astro.url.pathname, base);
 const t = createT(locale);
 const slug = Astro.params.slug;
 const songs = await getCollection('songs');
-const getSlug = (s: any) => s.data.slug || slugify(s.data.title);
-const entries = songs.filter((s) => getSlug(s) === slug);
+const entries = songs.filter((s) => s.slug === slug);
 if (entries.length === 0) {
   throw new Error(`Song not found: ${slug}`);
 }

--- a/src/pages/songs/index.astro
+++ b/src/pages/songs/index.astro
@@ -4,7 +4,6 @@ import { getCollection } from 'astro:content';
 import { getLocaleFromUrl, createT } from '../../utils/i18n';
 import artistFilterScript from '../../scripts/artistFilter.js?url';
 import { buildSeo } from '../../utils/seo';
-import { slugify } from '../../utils/urls';
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
@@ -14,7 +13,7 @@ const t = createT(locale);
 const all = await getCollection('songs');
 const map = new Map();
 for (const entry of all) {
-  const baseSlug = entry.data.slug || slugify(entry.data.title);
+  const baseSlug = entry.slug;
   const lang = entry.data.lang;
   const group = map.get(baseSlug) || {};
   group[lang] = entry;


### PR DESCRIPTION
## Summary
- Remove `slug` from songs content schema and generate slugs programmatically
- Use Astro's generated `entry.slug` in song pages instead of frontmatter

## Testing
- `npm test`
- `npm run build` *(warn: songs collection missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c3960469b08330ba8c1c45e0dc3dd0