### PR TITLE
feat: add Google Search Console verification option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ CONTENT_REPO=chords-content
 CONTENT_VERSION=v0.1.0
 CONTENT_FILENAME=content.zip
 CONTENT_SHA256=   # optional, leave blank
+PUBLIC_GSC_VERIFICATION=

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,7 @@ jobs:
       CONTENT_VERSION: ${{ vars.CONTENT_VERSION || 'v0.1.0' }}
       CONTENT_FILENAME: ${{ vars.CONTENT_FILENAME || 'content.zip' }}
       CONTENT_SHA256: ${{ vars.CONTENT_SHA256 || '' }}
+      PUBLIC_GSC_VERIFICATION: ${{ vars.PUBLIC_GSC_VERIFICATION || '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Run `npm run content:fetch` to download the bundle and populate `src/content/son
 Use `npm run content:clean` to remove fetched files.
 
 
+## Google Search Console
+
+Set `PUBLIC_GSC_VERIFICATION` in:
+
+- local `.env` for dev, and/or
+- GitHub repo "Variables" for CI (Settings → Secrets and variables → Actions → Variables).
+
+The tag will render only when a value is provided.
+
 ## Adding new songs
 
 1. Add an `.md` file in `src/content/songs/` with the song's frontmatter.

--- a/src/layouts/App.astro
+++ b/src/layouts/App.astro
@@ -17,9 +17,11 @@ const pathWithoutLocale = locale === 'en' ? relative.replace(/^en\//, '') : rela
 const altEs = `${base}${pathWithoutLocale}`;
 const altEn = `${base}en/${pathWithoutLocale}`;
 const year = new Date().getFullYear();
+const gsc = import.meta.env.PUBLIC_GSC_VERIFICATION;
 ---
 <html lang={locale} data-base={base} class="h-full">
   <head>
+    {gsc && <meta name="google-site-verification" content={gsc} />}
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />


### PR DESCRIPTION
## Summary
- expose `PUBLIC_GSC_VERIFICATION` variable in build workflow
- inject Google Search Console meta tag when verification code provided
- document the `PUBLIC_GSC_VERIFICATION` setting and add to `.env.example`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c453c9fee8833097794c51b8f5ce06