### PR TITLE
Add automatic sitemap generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ alias paths such as `/chords`, `/acordes` and `/cifrados`.
 Forks can update the `site` and `base` values in `astro.config.mjs` to point to
 their own URLs.
 
+During local development, the `base` setting is ignored; access the sitemap at
+`http://localhost:4321/sitemap-index.xml` rather than under the `/chordbook`
+prefix.
+
 After deployment, submit the sitemap URL (e.g.
 `https://acwilan.github.io/chordbook/sitemap-index.xml`) in Google Search
 Console.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ alias paths such as `/chords`, `/acordes` and `/cifrados`.
 Forks can update the `site` and `base` values in `astro.config.mjs` to point to
 their own URLs.
 
-During local development, the `base` setting is ignored; access the sitemap at
-`http://localhost:4321/sitemap-index.xml` rather than under the `/chordbook`
-prefix.
+The sitemap is generated only during `astro build`. Running `astro dev` will
+return a 404 for `/sitemap-index.xml`. To preview the sitemap locally, run
+`npm run build && npm run preview` and visit
+`http://localhost:4321/chordbook/sitemap-index.xml`.
 
 After deployment, submit the sitemap URL (e.g.
 `https://acwilan.github.io/chordbook/sitemap-index.xml`) in Google Search

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ Set `PUBLIC_GSC_VERIFICATION` in:
 
 The tag will render only when a value is provided.
 
+## Sitemap
+
+The sitemap is generated automatically at build time using the
+`@astrojs/sitemap` integration. It includes only canonical routes and omits
+alias paths such as `/chords`, `/acordes` and `/cifrados`.
+
+Forks can update the `site` and `base` values in `astro.config.mjs` to point to
+their own URLs.
+
+After deployment, submit the sitemap URL (e.g.
+`https://acwilan.github.io/chordbook/sitemap-index.xml`) in Google Search
+Console.
+
 ## Adding new songs
 
 1. Add an `.md` file in `src/content/songs/` with the song's frontmatter.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,14 @@ export default defineConfig({
   integrations: [
     tailwind(),
     sitemap({
-      filter: (page) => !/(\/((chords)|(acordes)|(cifrados))\/?)$/.test(page),
+      filter: (page) => {
+        const { pathname } = new URL(page);
+        const path = pathname.replace(/^\/chordbook/, '');
+        return (
+          /^\/(en\/)?($|songs\/(?:[^/]+\/?)?|changelog\/?$)/.test(path) &&
+          !/(\/(chords|acordes|cifrados)(\/?)$)/.test(path)
+        );
+      },
     }),
   ],
 });

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://acwilan.github.io/chordbook/sitemap.xml
+Sitemap: https://acwilan.github.io/chordbook/sitemap-index.xml


### PR DESCRIPTION
## Summary
- integrate @astrojs/sitemap with canonical route filtering
- update robots.txt to reference sitemap index
- document sitemap behavior and customization in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c45c25372c8330837b6289c07abc2e