### PR TITLE
fix: harden sitemap generation for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Console.
 - Each song has a canonical route at `/songs/{slug}/`. Keyword aliases (`/songs/{slug}/chords`, `/songs/{slug}/acordes`, `/songs/{slug}/cifrados`) render the same content but set `rel="canonical"` to the base route. Only canonical URLs appear in `sitemap.xml`.
 - Add optional `seoKeywords` in a song's frontmatter to append custom keywords to the defaults (`chords`, `acordes`, `cifrados`, artist, key).
 - Alias routes exist solely for discoverability and are excluded from the sitemap.
+- Submit `https://acwilan.github.io/chordbook/sitemap.xml` to search engines.
+- If GSC still errors, submit the child file `https://acwilan.github.io/chordbook/sitemap-0.xml`.
 
 ## Artist filter
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,14 +8,10 @@ export default defineConfig({
   integrations: [
     tailwind(),
     sitemap({
-      filter: (page) => {
-        const { pathname } = new URL(page);
-        const path = pathname.replace(/^\/chordbook/, '');
-        return (
-          /^\/(en\/)?($|songs\/(?:[^/]+\/?)?|changelog\/?$)/.test(path) &&
-          !/(\/(chords|acordes|cifrados)(\/?)$)/.test(path)
-        );
-      },
+      filter: (page) =>
+        !page.includes('/chords') &&
+        !page.includes('/acordes') &&
+        !page.includes('/cifrados'),
     }),
   ],
 });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "postbuild": "node scripts/postbuild-sitemap.cjs",
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest run",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
 Sitemap: https://acwilan.github.io/chordbook/sitemap-index.xml
+Sitemap: https://acwilan.github.io/chordbook/sitemap.xml

--- a/scripts/postbuild-sitemap.cjs
+++ b/scripts/postbuild-sitemap.cjs
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const { default: config } = await import('../astro.config.mjs');
+  const base = (config.base || '/').replace(/^\//, '').replace(/\/$/, '');
+  const preferred = path.join(process.cwd(), 'dist', base);
+  const outDir = fs.existsSync(preferred)
+    ? preferred
+    : path.join(process.cwd(), 'dist');
+  const source = path.join(outDir, 'sitemap-0.xml');
+  const target = path.join(outDir, 'sitemap.xml');
+
+  if (fs.existsSync(source)) {
+    fs.copyFileSync(source, target);
+  }
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- configure sitemap plugin to ignore chord aliases and support base URL
- add postbuild script to flatten sitemap output
- document sitemap submission and update robots.txt

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c48ef5cc5c83309f679e996a94f561